### PR TITLE
resolve swa-27, category empty state, common entries functionality

### DIFF
--- a/nest-note/Common/Views/BlurBackgroundLabel.swift
+++ b/nest-note/Common/Views/BlurBackgroundLabel.swift
@@ -9,14 +9,7 @@ class BlurBackgroundLabel: UIView {
         return label
     }()
     
-    private let blurView: UIVisualEffectView = {
-        let blur = UIBlurEffect(style: .systemUltraThinMaterial)
-        let view = UIVisualEffectView(effect: blur)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.layer.cornerRadius = 12
-        view.clipsToBounds = true
-        return view
-    }()
+    private var blurView: UIVisualEffectView!
     
     var onClearTapped: (() -> Void)?
     
@@ -40,13 +33,22 @@ class BlurBackgroundLabel: UIView {
         set { blurView.alpha = newValue }
     }
     
-    init() {
+    init(with effect: UIBlurEffect.Style = .systemUltraThinMaterial) {
         super.init(frame: .zero)
+        configureBlurView(with: effect)
         setupViews()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configureBlurView(with effect: UIBlurEffect.Style) {
+        let blur = UIBlurEffect(style: effect)
+        blurView = UIVisualEffectView(effect: blur)
+        blurView.translatesAutoresizingMaskIntoConstraints = false
+        blurView.layer.cornerRadius = 12
+        blurView.clipsToBounds = true
     }
     
     private func setupViews() {

--- a/nest-note/Common/Views/NNEmptyStateView.swift
+++ b/nest-note/Common/Views/NNEmptyStateView.swift
@@ -67,6 +67,8 @@ class NNEmptyStateView: UIView {
         addSubview(stackView)
         
         stackView.addArrangedSubview(iconImageView)
+        stackView.setCustomSpacing(16, after: iconImageView)
+
         stackView.addArrangedSubview(titleLabel)
         stackView.addArrangedSubview(subtitleLabel)
         stackView.addArrangedSubview(actionButton)
@@ -77,6 +79,8 @@ class NNEmptyStateView: UIView {
         isUserInteractionEnabled = true
         
         NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
             stackView.centerXAnchor.constraint(equalTo: centerXAnchor),
             stackView.centerYAnchor.constraint(equalTo: centerYAnchor),
             stackView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 32),
@@ -99,10 +103,14 @@ class NNEmptyStateView: UIView {
         if let buttonTitle = actionButtonTitle {
             actionButton.setTitle(buttonTitle, for: .normal)
             actionButton.isHidden = false
-            iconImageView.isHidden = true
         } else {
             actionButton.isHidden = true
-            iconImageView.isHidden = false
+        }
+
+        if let icon {
+            iconImageView.isHidden = false  
+        } else {
+            iconImageView.isHidden = true
         }
     }
     

--- a/nest-note/Helpers/UIViewController+BottomBlur.swift
+++ b/nest-note/Helpers/UIViewController+BottomBlur.swift
@@ -1,0 +1,36 @@
+import UIKit
+
+extension UIViewController {
+    /// Adds a blur effect view pinned to the bottom of the view controller's view.
+    /// - Parameters:
+    ///   - useSafeArea: Whether to use the safe area layout guide (default is true)
+    ///   - height: The height of the blur area (default is 55)
+    ///   - blurRadius: The radius of the blur effect (default is 16)
+    ///   - blurMaskImage: The mask image for the blur effect (default is nil)
+    /// - Returns: The created UIVisualEffectView for further customization if needed
+    @discardableResult
+    func pinBottomBlur(useSafeArea: Bool = true, height: CGFloat = 55, blurRadius: Double = 16, blurMaskImage: UIImage? = nil) -> UIVisualEffectView {
+        let visualEffectView = UIVisualEffectView()
+        visualEffectView.translatesAutoresizingMaskIntoConstraints = false
+        
+        if let maskImage = blurMaskImage {
+            visualEffectView.effect = UIBlurEffect.variableBlurEffect(radius: blurRadius, maskImage: maskImage)
+        } else {
+            visualEffectView.effect = UIBlurEffect(style: .regular)
+        }
+        
+        view.addSubview(visualEffectView)
+        
+        
+        let bottomAnchor = useSafeArea ? view.safeAreaLayoutGuide.bottomAnchor : view.bottomAnchor
+        
+        NSLayoutConstraint.activate([
+            visualEffectView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            visualEffectView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            visualEffectView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            visualEffectView.topAnchor.constraint(equalTo: bottomAnchor, constant: (-height) - 20)
+        ])
+        
+        return visualEffectView
+    }
+} 

--- a/nest-note/Scenes/Home/SitterHomeViewController.swift
+++ b/nest-note/Scenes/Home/SitterHomeViewController.swift
@@ -79,14 +79,10 @@ final class SitterHomeViewController: NNViewController, HomeViewControllerType {
             loadingSpinner.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             loadingSpinner.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             
-            emptyStateView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            emptyStateView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             emptyStateView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            emptyStateView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            emptyStateView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            emptyStateView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
-        
-        // Add a background color to the empty state view for debugging
-        emptyStateView.backgroundColor = UIColor.systemBackground.withAlphaComponent(0.9)
     }
     
     // MARK: - HomeViewControllerType Implementation

--- a/nest-note/Scenes/Nest/CommonEntriesViewController.swift
+++ b/nest-note/Scenes/Nest/CommonEntriesViewController.swift
@@ -1,0 +1,468 @@
+//
+//  CommonEntriesViewController.swift
+//  nest-note
+//
+//  Created by Colton Swapp on 1/21/25
+//
+
+import UIKit
+
+// Add a delegate protocol at the top of the file before class declaration
+protocol CommonEntriesViewControllerDelegate: AnyObject {
+    func commonEntriesViewController(_ controller: CommonEntriesViewController, didSelectEntry entry: BaseEntry)
+}
+
+class CommonEntriesViewController: UIViewController, CollectionViewLoadable {
+    // MARK: - Properties
+    private let entryRepository: EntryRepository
+    private let category: String
+    private let sessionVisibilityLevel: VisibilityLevel
+    
+    // Add delegate property
+    weak var delegate: EntryDetailViewControllerDelegate?
+    
+    // Required by CollectionViewLoadable
+    var loadingIndicator: UIActivityIndicatorView!
+    var refreshControl: UIRefreshControl!
+    
+    var collectionView: UICollectionView!
+    private var dataSource: UICollectionViewDiffableDataSource<Section, CommonEntry>!
+    
+    private var instructionLabel: BlurBackgroundLabel!
+    
+    private var emptyStateView: NNEmptyStateView!
+    
+    // Sections for the collection view - using same sections as NestCategoryViewController
+    enum Section: Int, CaseIterable {
+        case codes, other
+    }
+    
+    // Model for common entries
+    struct CommonEntry: Hashable {
+        let id = UUID().uuidString
+        let title: String
+        let content: String
+        let category: String
+        let visibility: VisibilityLevel
+        
+        // Convert to BaseEntry
+        func toBaseEntry() -> BaseEntry {
+            return BaseEntry(title: title, content: content, visibilityLevel: visibility, category: category)
+        }
+        
+        // Match the BaseEntry extension logic
+        var shouldUseHalfWidthCell: Bool {
+            return title.count <= 15 && content.count <= 15
+        }
+    }
+    
+    private var entries: [CommonEntry] = []
+    
+    init(category: String, entryRepository: EntryRepository, sessionVisibilityLevel: VisibilityLevel? = nil) {
+        self.category = category
+        self.entryRepository = entryRepository
+        // If it's a NestService (owner), they get comprehensive access. Otherwise use provided level or default to standard
+        self.sessionVisibilityLevel = entryRepository is NestService ? .comprehensive : (sessionVisibilityLevel ?? .standard)
+        super.init(nibName: nil, bundle: nil)
+        self.title = category
+        
+        // Load dummy data for the specific category
+        loadDummyData()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        setupCollectionView()
+        setupLoadingIndicator()
+        configureDataSource()
+        
+        collectionView.delegate = self
+        
+        setupEmptyStateView()
+        navigationItem.weeTitle = "Example Entries"
+        navigationController?.navigationBar.prefersLargeTitles = true
+        
+        // Set the navigation bar tint color to NNColors.primary
+        navigationController?.navigationBar.tintColor = NNColors.primary
+        
+        setupInstructionLabel()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        applySnapshot()
+    }
+    
+    // MARK: - CollectionViewLoadable Implementation
+    func handleLoadedData() {
+        // Not needed with static data
+    }
+    
+    func loadData(showLoadingIndicator: Bool) async {
+        // Not needed with static data
+    }
+    
+    private func setupInstructionLabel() {
+        pinBottomBlur(blurRadius: 16, blurMaskImage: UIImage(named: "testBG3"))
+        instructionLabel = BlurBackgroundLabel(with: .systemThinMaterial)
+        instructionLabel.translatesAutoresizingMaskIntoConstraints = false
+        instructionLabel.text = "These are example entries. Select \none to make it your own."
+        instructionLabel.font = .systemFont(ofSize: 16, weight: .regular)
+        instructionLabel.textColor = .secondaryLabel
+        
+        view.addSubview(instructionLabel)
+        
+        NSLayoutConstraint.activate([
+            instructionLabel.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            instructionLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            instructionLabel.widthAnchor.constraint(lessThanOrEqualTo: view.widthAnchor, multiplier: 0.8)
+        ])
+    }
+    
+    private func loadDummyData() {
+        // Only load entries for the current category
+        switch category {
+        case "Household":
+            entries = [
+                // Existing entries
+                CommonEntry(title: "Garage Code", content: "8005", category: category, visibility: .essential),
+                CommonEntry(title: "Front Door", content: "2208", category: category, visibility: .essential),
+                CommonEntry(title: "Trash Day", content: "Wednesday", category: category, visibility: .standard),
+                CommonEntry(title: "WiFi Password", content: "SuperStrongPassword", category: category, visibility: .essential),
+                CommonEntry(title: "Alarm Code", content: "4321", category: category, visibility: .essential),
+                CommonEntry(title: "Thermostat", content: "68°F", category: category, visibility: .standard),
+                CommonEntry(title: "Trash Pickup", content: "Wednesday Morning", category: category, visibility: .standard),
+                
+                CommonEntry(title: "Shed", content: "1357", category: category, visibility: .standard), // Short entry
+                CommonEntry(title: "Power Outage", content: "Flashlights in kitchen drawer", category: category, visibility: .standard),
+                CommonEntry(title: "Recycling", content: "Blue bin, Fridays", category: category, visibility: .standard),
+                CommonEntry(title: "Yard Service", content: "Every Monday, 11am-2pm", category: category, visibility: .extended),
+                CommonEntry(title: "Water Shutoff", content: "Basement, north wall", category: category, visibility: .standard),
+                CommonEntry(title: "Gas Shutoff", content: "Outside, east side of house", category: category, visibility: .standard)
+            ]
+            
+        case "Emergency":
+            entries = [
+                // Existing entries
+                CommonEntry(title: "Emergency Contact", content: "John Doe: 555-123-4567", category: category, visibility: .essential),
+                CommonEntry(title: "Nearest Hospital", content: "City General - 10 Main St", category: category, visibility: .essential),
+                CommonEntry(title: "Fire Evacuation", content: "Meet at mailbox", category: category, visibility: .essential),
+                CommonEntry(title: "Poison Control", content: "1-800-222-1222", category: category, visibility: .essential),
+                CommonEntry(title: "Home Doctor", content: "Dr. Smith: 555-987-6543", category: category, visibility: .standard),
+                
+                // New entries
+                CommonEntry(title: "911", content: "Address", category: category, visibility: .essential), // Short entry
+                CommonEntry(title: "EpiPen", content: "Top shelf", category: category, visibility: .essential), // Short entry
+                CommonEntry(title: "Safe", content: "3456", category: category, visibility: .essential), // Short entry
+                CommonEntry(title: "Allergies", content: "Peanuts, penicillin", category: category, visibility: .essential),
+                CommonEntry(title: "Insurance", content: "BlueCross #12345678", category: category, visibility: .standard),
+                CommonEntry(title: "Urgent Care", content: "WalkIn Clinic - 55 Grove St", category: category, visibility: .standard),
+                CommonEntry(title: "Power Company", content: "CityPower: 555-789-0123", category: category, visibility: .standard),
+                CommonEntry(title: "Plumber", content: "Joe's Plumbing: 555-456-7890", category: category, visibility: .standard),
+                CommonEntry(title: "Neighbor Help", content: "Mrs. Wilson: 555-234-5678", category: category, visibility: .standard)
+            ]
+            
+        case "Rules & Guidelines":
+            entries = [
+                // Existing entries
+                CommonEntry(title: "Bedtime", content: "9:00 PM on weekdays", category: category, visibility: .standard),
+                CommonEntry(title: "Screen Time", content: "2 hours max per day", category: category, visibility: .standard),
+                CommonEntry(title: "House Rules", content: "No shoes indoors", category: category, visibility: .essential),
+                CommonEntry(title: "Chores", content: "Take out trash on Wednesday", category: category, visibility: .standard),
+                
+                // New entries
+                CommonEntry(title: "Snacks", content: "After 3pm", category: category, visibility: .standard), // Short entry
+                CommonEntry(title: "No TV", content: "After 8pm", category: category, visibility: .standard), // Short entry
+                CommonEntry(title: "Bath", content: "7:30pm", category: category, visibility: .standard), // Short entry
+                CommonEntry(title: "Books", content: "2 at bed", category: category, visibility: .standard), // Short entry
+                CommonEntry(title: "Meal Times", content: "Breakfast 7am, Lunch 12pm, Dinner 6pm", category: category, visibility: .standard),
+                CommonEntry(title: "Off-Limits", content: "Dad's office and workshop", category: category, visibility: .essential),
+                CommonEntry(title: "Study Hour", content: "4pm-5pm weekdays", category: category, visibility: .standard),
+                CommonEntry(title: "Playroom Rules", content: "Clean up before moving to next activity", category: category, visibility: .standard),
+                CommonEntry(title: "Phone Use", content: "Only after homework is completed", category: category, visibility: .standard),
+                CommonEntry(title: "Guest Policy", content: "Parents must approve all visitors", category: category, visibility: .standard),
+                CommonEntry(title: "Allowance", content: "$5 weekly, given on Sunday", category: category, visibility: .extended)
+            ]
+            
+        case "Pets":
+            entries = [
+                // Existing entries
+                CommonEntry(title: "Feeding Schedule", content: "Morning: 7am, Evening: 6pm", category: category, visibility: .standard),
+                CommonEntry(title: "Vet Contact", content: "Dr. Smith: 555-987-6543", category: category, visibility: .standard),
+                CommonEntry(title: "Walking Schedule", content: "Morning and evening", category: category, visibility: .standard),
+                CommonEntry(title: "Medication", content: "Flea medicine on the 1st", category: category, visibility: .essential),
+                
+                // New entries
+                CommonEntry(title: "Dog Food", content: "1 cup", category: category, visibility: .essential), // Short entry
+                CommonEntry(title: "Cat", content: "Indoor", category: category, visibility: .essential), // Short entry
+                CommonEntry(title: "Fish", content: "Feed 2x", category: category, visibility: .standard), // Short entry
+                CommonEntry(title: "Toys", content: "In bin", category: category, visibility: .standard), // Short entry
+                CommonEntry(title: "Treat Rules", content: "Max 2 per day", category: category, visibility: .standard),
+                CommonEntry(title: "Pet Names", content: "Dog: Max, Cat: Luna, Fish: Bubbles", category: category, visibility: .essential),
+                CommonEntry(title: "No-Go Areas", content: "Keep pets out of formal dining room", category: category, visibility: .standard),
+                CommonEntry(title: "Pet Sitter", content: "Emily: 555-222-3333", category: category, visibility: .extended),
+                CommonEntry(title: "Leash Location", content: "Hanging by front door", category: category, visibility: .standard),
+                CommonEntry(title: "Pet Emergency", content: "Animal Hospital: 555-789-4561", category: category, visibility: .essential),
+                CommonEntry(title: "Special Needs", content: "Dog afraid of thunderstorms", category: category, visibility: .standard)
+            ]
+            
+        case "School & Education":
+            entries = [
+                // Existing entries
+                CommonEntry(title: "School Hours", content: "8:30am - 3:15pm", category: category, visibility: .standard),
+                CommonEntry(title: "Bus Schedule", content: "Pickup: 7:45am, Drop-off: 3:30pm", category: category, visibility: .standard),
+                CommonEntry(title: "Teacher Contact", content: "Ms. Johnson: johnson@school.edu", category: category, visibility: .standard),
+                CommonEntry(title: "Homework Time", content: "4:00pm - 5:30pm", category: category, visibility: .standard),
+                
+                // New entries
+                CommonEntry(title: "Math Help", content: "Dad", category: category, visibility: .standard), // Short entry
+                CommonEntry(title: "Books", content: "20 mins", category: category, visibility: .standard), // Short entry
+                CommonEntry(title: "Band", content: "Tuesdays", category: category, visibility: .standard), // Short entry
+                CommonEntry(title: "Tutor", content: "Thursdays", category: category, visibility: .extended), // Short entry
+                CommonEntry(title: "School Address", content: "123 Learning Lane", category: category, visibility: .standard),
+                CommonEntry(title: "Principal", content: "Dr. Martinez: 555-321-9876", category: category, visibility: .standard),
+                CommonEntry(title: "Library Day", content: "Wednesday - books due back", category: category, visibility: .standard),
+                CommonEntry(title: "School Nurse", content: "Ms. Garcia: 555-321-8765", category: category, visibility: .standard),
+                CommonEntry(title: "Study Buddies", content: "Alex and Jamie on Mondays", category: category, visibility: .extended),
+                CommonEntry(title: "School Website", content: "www.cityschool.edu/portal", category: category, visibility: .standard),
+                CommonEntry(title: "Class Schedule", content: "In blue folder on desk", category: category, visibility: .standard),
+                CommonEntry(title: "Project Due", content: "Science fair - May 15", category: category, visibility: .standard)
+            ]
+            
+        case "Social & Interpersonal":
+            entries = [
+                // Existing entries
+                CommonEntry(title: "Playdate Rules", content: "No more than 2 friends at a time", category: category, visibility: .extended),
+                CommonEntry(title: "Known Allergies", content: "None", category: category, visibility: .standard),
+                CommonEntry(title: "Approved Friends", content: "Sarah, Jake, Emma", category: category, visibility: .extended),
+                CommonEntry(title: "Parent Contacts", content: "Sarah's mom: 555-111-2222", category: category, visibility: .standard),
+                
+                // New entries
+                CommonEntry(title: "Calm Down", content: "Count to 10", category: category, visibility: .standard), // Short entry
+                CommonEntry(title: "Shy", content: "Be patient", category: category, visibility: .standard), // Short entry
+                CommonEntry(title: "Upset", content: "Hug helps", category: category, visibility: .standard), // Short entry
+                CommonEntry(title: "Nap", content: "With bear", category: category, visibility: .standard), // Short entry
+                CommonEntry(title: "Comfort Item", content: "Blue blanket in bedroom", category: category, visibility: .standard),
+                CommonEntry(title: "Mood Signs", content: "Quiet when overwhelmed", category: category, visibility: .standard),
+                CommonEntry(title: "Social Cues", content: "Needs reminders to share", category: category, visibility: .standard),
+                CommonEntry(title: "Friend Homes", content: "Allowed at Jake and Emma's", category: category, visibility: .extended),
+                CommonEntry(title: "Fears", content: "Afraid of the dark, use night light", category: category, visibility: .standard),
+                CommonEntry(title: "Family Photos", content: "In living room bookshelf", category: category, visibility: .standard),
+                CommonEntry(title: "Cultural Notes", content: "No meat on Fridays", category: category, visibility: .standard),
+                CommonEntry(title: "Conversation", content: "Loves talking about dinosaurs", category: category, visibility: .standard)
+            ]
+            
+        default:
+            entries = [
+                CommonEntry(title: "Playdate Rules", content: "No more than 2 friends at a time", category: category, visibility: .extended),
+                CommonEntry(title: "Trash Day", content: "Wednesday", category: category, visibility: .standard),
+                CommonEntry(title: "Water Shutoff", content: "Basement, north wall", category: category, visibility: .standard),
+                CommonEntry(title: "EpiPen", content: "Top shelf", category: category, visibility: .essential), // Short entry
+                CommonEntry(title: "Power Company", content: "CityPower: 555-789-0123", category: category, visibility: .standard),
+                CommonEntry(title: "House Rules", content: "No shoes indoors", category: category, visibility: .essential),
+                CommonEntry(title: "No TV", content: "After 8pm", category: category, visibility: .standard), // Short entry
+                CommonEntry(title: "Phone Use", content: "Only after homework is completed", category: category, visibility: .standard),
+                CommonEntry(title: "Dog Food", content: "1 cup", category: category, visibility: .essential), // Short entry
+                CommonEntry(title: "School Address", content: "123 Learning Lane", category: category, visibility: .standard),
+                CommonEntry(title: "Parent Contacts", content: "Sarah's mom: 555-111-2222", category: category, visibility: .standard),
+            ]
+        }
+    }
+    
+    private func setupLoadingIndicator() {
+        loadingIndicator = UIActivityIndicatorView(style: .large)
+        loadingIndicator.hidesWhenStopped = true
+        loadingIndicator.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(loadingIndicator)
+        
+        NSLayoutConstraint.activate([
+            loadingIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            loadingIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+    }
+    
+    private func setupCollectionView() {
+        collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: createLayout())
+        collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        collectionView.backgroundColor = .systemBackground
+        view.addSubview(collectionView)
+        
+        let buttonHeight: CGFloat = 50
+        let buttonPadding: CGFloat = 10
+        let totalInset = buttonHeight + buttonPadding * 2
+        collectionView.contentInset.bottom = totalInset
+        collectionView.verticalScrollIndicatorInsets.bottom = totalInset
+        
+        // Register cells
+        collectionView.register(FullWidthCell.self, forCellWithReuseIdentifier: FullWidthCell.reuseIdentifier)
+        collectionView.register(HalfWidthCell.self, forCellWithReuseIdentifier: HalfWidthCell.reuseIdentifier)
+        
+        collectionView.allowsSelection = true
+    }
+    
+    private func createLayout() -> UICollectionViewLayout {
+        let layout = UICollectionViewCompositionalLayout { [weak self] (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
+            guard let self = self else { return nil }
+            
+            let section = Section(rawValue: sectionIndex)!
+            switch section {
+            case .codes:
+                return self.createHalfWidthSection()
+            case .other:
+                return self.createInsetGroupedSection()
+            }
+        }
+        return layout
+    }
+    
+    private func createHalfWidthSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(0.5), heightDimension: .absolute(90))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        item.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(90))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, repeatingSubitem: item, count: 2)
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 4, bottom: 12, trailing: 4)
+        
+        return section
+    }
+    
+    private func createInsetGroupedSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(44))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(44))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 12, bottom: 12, trailing: 12)
+        section.interGroupSpacing = 8
+        
+        return section
+    }
+    
+    private func configureDataSource() {
+        dataSource = UICollectionViewDiffableDataSource<Section, CommonEntry>(collectionView: collectionView) {
+            [weak self] (collectionView, indexPath, entry) -> UICollectionViewCell? in
+            guard let self = self else { return nil }
+            
+            let section = Section(rawValue: indexPath.section)!
+
+            switch section {
+            case .codes:
+                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: HalfWidthCell.reuseIdentifier, for: indexPath) as! HalfWidthCell
+                cell.valueContainerBackgroundColor = NNColors.NNSystemBackground6
+                cell.configure(
+                    key: entry.title,
+                    value: entry.content,
+                    entryVisibility: entry.visibility,
+                    sessionVisibility: self.sessionVisibilityLevel
+                )
+                
+                return cell
+            case .other:
+                let cell = collectionView.dequeueReusableCell(withReuseIdentifier: FullWidthCell.reuseIdentifier, for: indexPath) as! FullWidthCell
+                cell.valueContainerBackgroundColor = NNColors.NNSystemBackground6
+                cell.configure(
+                    key: entry.title,
+                    value: entry.content,
+                    entryVisibility: entry.visibility,
+                    sessionVisibility: self.sessionVisibilityLevel
+                )
+                
+                return cell
+            }
+        }
+    }
+    
+    private func createSnapshot() -> NSDiffableDataSourceSnapshot<Section, CommonEntry> {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, CommonEntry>()
+        
+        snapshot.appendSections([.codes, .other])
+        
+        // Filter and sort entries based on cell type
+        let codesEntries = entries.filter { $0.shouldUseHalfWidthCell }
+            .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+        let otherEntries = entries.filter { !$0.shouldUseHalfWidthCell }
+            .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+        
+        snapshot.appendItems(codesEntries, toSection: .codes)
+        snapshot.appendItems(otherEntries, toSection: .other)
+        
+        return snapshot
+    }
+    
+    private func applySnapshot() {
+        let snapshot = createSnapshot()
+        dataSource.apply(snapshot, animatingDifferences: false)
+        
+        // Show empty state view if no entries
+        emptyStateView.isHidden = !entries.isEmpty
+    }
+    
+    private func setupEmptyStateView() {
+        emptyStateView = NNEmptyStateView(
+            icon: UIImage(systemName: "square.grid.2x2"),
+            title: "No Suggestions",
+            subtitle: "We don't have any suggestions for this category at the moment.",
+            actionButtonTitle: nil
+        )
+        emptyStateView.translatesAutoresizingMaskIntoConstraints = false
+        emptyStateView.isHidden = true
+        emptyStateView.isUserInteractionEnabled = true
+        
+        view.addSubview(emptyStateView)
+        
+        NSLayoutConstraint.activate([
+            emptyStateView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            emptyStateView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            emptyStateView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+    }
+}
+
+extension CommonEntriesViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        collectionView.deselectItem(at: indexPath, animated: true)
+        
+        guard let selectedEntry = dataSource.itemIdentifier(for: indexPath),
+              let cell = collectionView.cellForItem(at: indexPath) else { return }
+        
+        Logger.log(level: .info, category: .nestService, message: "Selected common entry: \(selectedEntry.title)")
+        
+        // Create a BaseEntry from the CommonEntry
+        let baseEntry = selectedEntry.toBaseEntry()
+        
+        let cellFrame = collectionView.convert(cell.frame, to: nil)
+        let isReadOnly = !(entryRepository is NestService)
+        
+        let editEntryVC = EntryDetailViewController(
+            category: selectedEntry.category,
+            title: selectedEntry.title,
+            content: selectedEntry.content,
+            sourceFrame: cellFrame
+        )
+        editEntryVC.entryDelegate = self
+        present(editEntryVC, animated: true)
+    }
+}
+
+extension CommonEntriesViewController: EntryDetailViewControllerDelegate {
+    func entryDetailViewController(didSaveEntry entry: BaseEntry?) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            self.dismiss(animated: true, completion: nil)
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.delegate?.entryDetailViewController(didSaveEntry: entry)
+        }
+    }
+    
+    func entryDetailViewController(didDeleteEntry entry: BaseEntry) {
+        //
+    }
+}

--- a/nest-note/Scenes/Nest/CustomCells/FullWidthCell.swift
+++ b/nest-note/Scenes/Nest/CustomCells/FullWidthCell.swift
@@ -13,6 +13,8 @@ class FullWidthCell: UICollectionViewCell {
     private let keyLabel = UILabel()
     private let valueLabel = UILabel()
     
+    var valueContainerBackgroundColor: UIColor = NNColors.groupedBackground
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupViews()
@@ -51,7 +53,7 @@ class FullWidthCell: UICollectionViewCell {
         ])
         
         containerView.clipsToBounds = true
-        containerView.backgroundColor = NNColors.groupedBackground
+        containerView.backgroundColor = valueContainerBackgroundColor
         containerView.layer.cornerRadius = 10
 
         keyLabel.font = UIFont.systemFont(ofSize: 14, weight: .medium)
@@ -74,12 +76,14 @@ class FullWidthCell: UICollectionViewCell {
             valueLabel.text = "********"
             valueLabel.textColor = .label
         }
+        
+        containerView.backgroundColor = valueContainerBackgroundColor
     }
     
     override var isHighlighted: Bool {
         didSet {
             UIView.animate(withDuration: 0.1) {
-                self.containerView.backgroundColor = self.isHighlighted ? .systemGray4 : NNColors.groupedBackground
+                self.containerView.backgroundColor = self.isHighlighted ? .systemGray4 : self.valueContainerBackgroundColor
             }
         }
     }
@@ -89,7 +93,7 @@ class FullWidthCell: UICollectionViewCell {
             self.containerView.backgroundColor = NNColors.primary.withAlphaComponent(0.3)
         }) { _ in
             UIView.animate(withDuration: 0.3) {
-                self.containerView.backgroundColor = NNColors.groupedBackground
+                self.containerView.backgroundColor = self.valueContainerBackgroundColor
             }
         }
     }

--- a/nest-note/Scenes/Nest/CustomCells/HalfWidthCell.swift
+++ b/nest-note/Scenes/Nest/CustomCells/HalfWidthCell.swift
@@ -13,6 +13,8 @@ class HalfWidthCell: UICollectionViewCell {
     private let keyLabel = UILabel()
     private let valueLabel = UILabel()
     
+    var valueContainerBackgroundColor: UIColor = NNColors.groupedBackground
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupViews()
@@ -53,7 +55,7 @@ class HalfWidthCell: UICollectionViewCell {
         keyLabel.textColor = .secondaryLabel
         
         valueContainer.clipsToBounds = true
-        valueContainer.backgroundColor = NNColors.groupedBackground
+        valueContainer.backgroundColor = valueContainerBackgroundColor
         valueContainer.layer.cornerRadius = 10
         
         valueLabel.font = UIFont.systemFont(ofSize: 22)
@@ -72,12 +74,14 @@ class HalfWidthCell: UICollectionViewCell {
             valueLabel.text = "****"
             valueLabel.textColor = .label
         }
+        
+        valueContainer.backgroundColor = valueContainerBackgroundColor
     }
     
     override var isHighlighted: Bool {
         didSet {
             UIView.animate(withDuration: 0.1) {
-                self.valueContainer.backgroundColor = self.isHighlighted ? .systemGray4 : NNColors.groupedBackground
+                self.valueContainer.backgroundColor = self.isHighlighted ? .systemGray4 : self.valueContainerBackgroundColor
             }
         }
     }
@@ -87,7 +91,7 @@ class HalfWidthCell: UICollectionViewCell {
             self.valueContainer.backgroundColor = NNColors.primary.withAlphaComponent(0.3)
         }) { _ in
             UIView.animate(withDuration: 0.3) {
-                self.valueContainer.backgroundColor = NNColors.groupedBackground
+                self.valueContainer.backgroundColor = self.valueContainerBackgroundColor
             }
         }
     }

--- a/nest-note/Scenes/Nest/EntryDetailViewController.swift
+++ b/nest-note/Scenes/Nest/EntryDetailViewController.swift
@@ -1,7 +1,8 @@
 import UIKit
 
 protocol EntryDetailViewControllerDelegate: AnyObject {
-    func entryDetailViewController(_ controller: EntryDetailViewController, didSaveEntry entry: BaseEntry?)
+    func entryDetailViewController(didSaveEntry entry: BaseEntry?)
+    func entryDetailViewController(didDeleteEntry entry: BaseEntry)
 }
 
 final class EntryDetailViewController: NNSheetViewController {
@@ -73,6 +74,17 @@ final class EntryDetailViewController: NNSheetViewController {
         self.visibilityLevel = entry?.visibility ?? .standard
         self.isReadOnly = isReadOnly
         super.init(sourceFrame: sourceFrame)
+    }
+    
+    init(category: String, title: String, content: String, sourceFrame: CGRect? = nil) {
+        self.category = category
+        self.entry = nil
+        self.visibilityLevel = .standard
+        self.isReadOnly = false
+        super.init(sourceFrame: sourceFrame)
+        
+        titleField.text = title
+        contentTextView.text = content
     }
     
     required init?(coder: NSCoder) {
@@ -245,7 +257,7 @@ final class EntryDetailViewController: NNSheetViewController {
             do {
                 try await NestService.shared.deleteEntry(entry)
                 await MainActor.run {
-                    entryDelegate?.entryDetailViewController(self, didSaveEntry: nil)
+                    entryDelegate?.entryDetailViewController(didDeleteEntry: entry)
                     HapticsHelper.lightHaptic()
                     dismiss(animated: true)
                 }
@@ -332,7 +344,7 @@ final class EntryDetailViewController: NNSheetViewController {
                 }
                 
                 HapticsHelper.lightHaptic()
-                entryDelegate?.entryDetailViewController(self, didSaveEntry: savedEntry)
+                entryDelegate?.entryDetailViewController(didSaveEntry: savedEntry)
                 dismiss(animated: true)
             }
         }

--- a/nest-note/Scenes/Nest/NestViewController.swift
+++ b/nest-note/Scenes/Nest/NestViewController.swift
@@ -309,6 +309,7 @@ class NestViewController: NNViewController, NestLoadable {
         guard entryRepository is NestService else { return }
         
         newCategoryButton = NNPrimaryLabeledButton(title: "New Category", image: UIImage(systemName: "plus"))
+        newCategoryButton.isEnabled = false
         newCategoryButton.pinToBottom(of: view, addBlurEffect: true, blurRadius: 16, blurMaskImage: UIImage(named: "testBG3"))
         newCategoryButton.addTarget(self, action: #selector(addButtonTapped), for: .touchUpInside)
         
@@ -335,6 +336,7 @@ class NestViewController: NNViewController, NestLoadable {
             self.categories = categories
             
             await MainActor.run {
+                self.newCategoryButton.isEnabled = true
                 self.hasLoadedInitialData = true
                 self.handleLoadedEntries(groupedEntries)
                 self.loadingIndicator.stopAnimating()
@@ -342,6 +344,7 @@ class NestViewController: NNViewController, NestLoadable {
         } catch {
             Logger.log(level: .error, category: .general, message: "Failed to load entries and categories: \(error)")
             await MainActor.run {
+                self.newCategoryButton.isEnabled = false
                 self.loadingIndicator.stopAnimating()
                 self.showError(error.localizedDescription)
             }

--- a/nest-note/Scenes/Settings/SettingsViewController.swift
+++ b/nest-note/Scenes/Settings/SettingsViewController.swift
@@ -644,12 +644,12 @@ extension SettingsViewController: CategoryDetailViewControllerDelegate {
 }
 
 extension SettingsViewController: EntryDetailViewControllerDelegate {
-    func entryDetailViewController(_ controller: EntryDetailViewController, didSaveEntry entry: BaseEntry?) {
-        if let entry = entry {
-            showToast(text: "Entry saved: \(entry.title)")
-        } else {
-            showToast(text: "Entry deleted")
-        }
+    func entryDetailViewController(didDeleteEntry: BaseEntry) {
+        showToast(text: "Entry saved: \(didDeleteEntry.title)")
+    }
+    
+    func entryDetailViewController(didSaveEntry entry: BaseEntry?) {
+        //
     }
 }
 

--- a/nest-note/Scenes/Settings/ViewControllers/EntryReviewViewController.swift
+++ b/nest-note/Scenes/Settings/ViewControllers/EntryReviewViewController.swift
@@ -366,11 +366,11 @@ class EntryReviewViewController: NNViewController, CardStackViewDelegate {
 
 // Add this extension to handle entry updates
 extension EntryReviewViewController: EntryDetailViewControllerDelegate {
-    func entryDetailViewController(_ controller: EntryDetailViewController, didSaveEntry entry: BaseEntry?) {
+    func entryDetailViewController(didSaveEntry entry: BaseEntry?) {
         guard let entry = entry else {
             // Handle deletion - just show a toast, no need to refresh the entire stack
             // We can keep the card in the visual stack but mark it as deleted if needed
-            if let editingEntry = controller.entry {
+            if let editingEntry = entry {
                 showToast(text: "Entry deleted")
                 Logger.log(level: .info, category: .nestService, message: "Entry deleted: \(editingEntry.id)")
             }
@@ -394,5 +394,9 @@ extension EntryReviewViewController: EntryDetailViewControllerDelegate {
                 }
             }
         }
+    }
+    
+    func entryDetailViewController(didDeleteEntry entry: BaseEntry) {
+        //
     }
 }

--- a/nest-note/Services/NestService.swift
+++ b/nest-note/Services/NestService.swift
@@ -98,13 +98,10 @@ final class NestService: EntryRepository {
         let docRef = db.collection("nests").document(nest.id)
         try await docRef.setData(try Firestore.Encoder().encode(nest))
         
-        // Create default categories first
+        // Create default categories
         try await createDefaultCategories(for: nest.id)
         
-        // Then create default entries
-        try await createDefaultEntries(for: nest.id)
-        
-        Logger.log(level: .info, category: .nestService, message: "Nest created successfully with default categories and entries ✅")
+        Logger.log(level: .info, category: .nestService, message: "Nest created successfully with default categories ✅")
         
         // Set as current nest after creation
         setCurrentNest(nest)
@@ -251,15 +248,6 @@ final class NestService: EntryRepository {
         cachedEntries = nil
     }
     
-    // Creates default entries for a new nest
-    func createDefaultEntries(for nestId: String) async throws {
-        for entry in Self.defaultEntries {
-            let docRef = db.collection("nests").document(nestId).collection("entries").document(entry.id)
-            try await docRef.setData(try Firestore.Encoder().encode(entry))
-        }
-        Logger.log(level: .info, category: .nestService, message: "Created \(Self.defaultEntries.count) default entries")
-    }
-    
     // Add this method to find entries older than a specified timeframe
     func fetchOutdatedEntries(olderThan days: Int = 90) async throws -> [BaseEntry] {
         // Fetch all entries first
@@ -295,50 +283,6 @@ extension NestService {
             }
         }
     }
-}
-
-// MARK: - Default Entries
-extension NestService {
-    static let defaultEntries: [BaseEntry] = [
-        // Household
-        BaseEntry(title: "Garage Code", content: "--", visibilityLevel: .essential, category: "Household"),
-        BaseEntry(title: "Alarm Code", content: "--", visibilityLevel: .essential, category: "Household"),
-        BaseEntry(title: "WiFi Setup", content: "--", visibilityLevel: .essential, category: "Household"),
-        BaseEntry(title: "Appliance Guide", content: "--", visibilityLevel: .standard, category: "Household"),
-        BaseEntry(title: "Trash Schedule", content: "--", visibilityLevel: .standard, category: "Household"),
-        
-        // Emergency
-        BaseEntry(title: "Medical Info", content: "--", visibilityLevel: .essential, category: "Emergency"),
-        BaseEntry(title: "First Aid Location", content: "--", visibilityLevel: .essential, category: "Emergency"),
-        BaseEntry(title: "Emergency Shutoffs", content: "--", visibilityLevel: .essential, category: "Emergency"),
-        BaseEntry(title: "Nearest Hospital", content: "--", visibilityLevel: .essential, category: "Emergency"),
-        
-        // Rules & Guidelines
-        BaseEntry(title: "House Rules", content: "--", visibilityLevel: .essential, category: "Rules & Guidelines"),
-        BaseEntry(title: "Screen Time", content: "--", visibilityLevel: .essential, category: "Rules & Guidelines"),
-        BaseEntry(title: "Approved Media", content: "--", visibilityLevel: .standard, category: "Rules & Guidelines"),
-        BaseEntry(title: "Food Rules", content: "--", visibilityLevel: .essential, category: "Rules & Guidelines"),
-        BaseEntry(title: "Off-Limits Areas", content: "--", visibilityLevel: .essential, category: "Rules & Guidelines"),
-        
-        // Pets
-        BaseEntry(title: "Schedule", content: "--", visibilityLevel: .essential, category: "Pets"),
-        BaseEntry(title: "Vet Info", content: "--", visibilityLevel: .standard, category: "Pets"),
-        BaseEntry(title: "Behavior", content: "--", visibilityLevel: .essential, category: "Pets"),
-        BaseEntry(title: "Medications", content: "--", visibilityLevel: .essential, category: "Pets"),
-        BaseEntry(title: "Exercise Routine", content: "--", visibilityLevel: .standard, category: "Pets"),
-        
-        // School & Education
-        BaseEntry(title: "School Details", content: "--", visibilityLevel: .standard, category: "School & Education"),
-        BaseEntry(title: "Transportation", content: "--", visibilityLevel: .standard, category: "School & Education"),
-        BaseEntry(title: "Homework Rules", content: "--", visibilityLevel: .standard, category: "School & Education"),
-        
-        // Social & Interpersonal
-        BaseEntry(title: "Approved Friends", content: "--", visibilityLevel: .standard, category: "Social & Interpersonal"),
-        BaseEntry(title: "Playdate Contacts", content: "--", visibilityLevel: .extended, category: "Social & Interpersonal"),
-        BaseEntry(title: "Behavior Guide", content: "--", visibilityLevel: .standard, category: "Social & Interpersonal"),
-        BaseEntry(title: "Comfort Routines", content: "--", visibilityLevel: .standard, category: "Social & Interpersonal"),
-        BaseEntry(title: "Cultural Notes", content: "--", visibilityLevel: .standard, category: "Social & Interpersonal")
-    ]
 }
 
 // MARK: - Default Categories


### PR DESCRIPTION
- Empty states for the `NestCategoryViewController`
- Functionality for showing `Example Entries` which can be turned into the user's own entries

![image](https://github.com/user-attachments/assets/a1d2d5f1-b565-495c-8f5e-e39af96bc6b9)
![image](https://github.com/user-attachments/assets/78b41262-a9a8-45ca-9465-b2de745ccee3)
