### PR TITLE
Fix session title whitespace and add flashing placeholder

### DIFF
--- a/nest-note/Common/Views/FlashingPlaceholderTextField.swift
+++ b/nest-note/Common/Views/FlashingPlaceholderTextField.swift
@@ -73,7 +73,6 @@ class FlashingPlaceholderTextField: UITextField {
     
     // Stop animation when text field becomes first responder
     override func becomeFirstResponder() -> Bool {
-        isAnimating = false
         return super.becomeFirstResponder()
     }
     

--- a/nest-note/Scenes/Sessions/EditSessionViewController.swift
+++ b/nest-note/Scenes/Sessions/EditSessionViewController.swift
@@ -44,13 +44,21 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
     // 4 day, multi-day session by default
     private var initialDate: (startDate: Date, endDate: Date, isMultiDay: Bool) = (startDate: Date().roundedToNextHour(), endDate: Date().addingTimeInterval(60 * 60 * 96).roundedToNextHour(), isMultiDay: true)
     
-    private let titleTextField: UITextField = {
-        let field = UITextField()
-        field.placeholder = "Session Title"
+    private let titleTextField: FlashingPlaceholderTextField = {
+        let placeholders = [
+            "Date Night",
+            "Weekend Getaway", 
+            "Anniversary Trip",
+            "Birthday Trip",
+            "Family Vacation",
+            "Business Trip",
+            "Sleepover",
+            "Evening Out"
+        ]
+        let field = FlashingPlaceholderTextField(placeholders: placeholders)
         field.font = .h2
         field.borderStyle = .none
         field.returnKeyType = .done
-        field.placeholder = "Session Title"
         return field
     }()
     
@@ -660,10 +668,13 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
         Task {
             do {
                 // Validate required fields
-                guard let title = titleTextField.text, !title.isEmpty else {
+                guard let titleText = titleTextField.text, !titleText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                     showToast(text: "Please enter a session title", sentiment: .negative)
                     return
                 }
+                
+                // Trim whitespace from title
+                let title = titleText.trimmingCharacters(in: .whitespacesAndNewlines)
                 
                 guard let dateItem = dataSource.snapshot().itemIdentifiers(inSection: .date).first,
                       case let .dateSelection(startDate, endDate, isMultiDay) = dateItem else {

--- a/nest-note/Scenes/Sessions/EditSessionViewController.swift
+++ b/nest-note/Scenes/Sessions/EditSessionViewController.swift
@@ -51,8 +51,7 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
             "Anniversary Trip",
             "Birthday Trip",
             "Family Vacation",
-            "Business Trip",
-            "Sleepover",
+            "Sleepover w/ Grandma",
             "Evening Out"
         ]
         let field = FlashingPlaceholderTextField(placeholders: placeholders)


### PR DESCRIPTION
Trims whitespace from session titles on save and adds a flashing placeholder text field with rotating suggestions.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd9fb8c7-7b2e-4735-bdf3-5eab62b16cac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd9fb8c7-7b2e-4735-bdf3-5eab62b16cac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

