### PR TITLE
closes swa-82, swa-94, swa-95, swa-93

### DIFF
--- a/nest-note/Common/Utilities/NNTipModel.swift
+++ b/nest-note/Common/Utilities/NNTipModel.swift
@@ -63,15 +63,8 @@ enum NestCategoryTips {
     static let entrySuggestionTip = NNTipModel(
         id: "EntrySuggestionTip",
         title: "Need Inspiration?",
-        message: "Browse our collection of entry suggestions.",
+        message: "Browse our collection of item suggestions.",
         systemImageName: "sparkles"
-    )
-    
-    static let entriesLiveHereTip = NNTipModel(
-        id: "EntriesLiveHereTip",
-        title: "Entries Live Here",
-        message: "Add information babysitters need - codes, rules, contacts, and more.",
-        systemImageName: "note.text"
     )
 }
 

--- a/nest-note/Common/Views/FlashingPlaceholderTextField.swift
+++ b/nest-note/Common/Views/FlashingPlaceholderTextField.swift
@@ -24,6 +24,8 @@ class FlashingPlaceholderTextField: UITextField {
         super.init(frame: .zero)
         self.placeholders = placeholders
         self.placeholder = placeholders.first
+        
+        addTarget(self, action: #selector(textChanged), for: .editingChanged)
     }
     
     required init?(coder: NSCoder) {
@@ -41,6 +43,14 @@ class FlashingPlaceholderTextField: UITextField {
         timer = Timer.scheduledTimer(withTimeInterval: holdDuration, repeats: true) { [weak self] _ in
             self?.animateNextPlaceholder()
         }
+    }
+    
+    @objc func textChanged() {
+      if let text = text, !text.isEmpty {
+        stopAnimating()
+      } else {
+        startAnimating()
+      }
     }
     
     private func stopAnimating() {
@@ -87,4 +97,4 @@ class FlashingPlaceholderTextField: UITextField {
     deinit {
         stopAnimating()
     }
-} 
+}

--- a/nest-note/Common/Views/FlashingPlaceholderTextField.swift
+++ b/nest-note/Common/Views/FlashingPlaceholderTextField.swift
@@ -73,7 +73,6 @@ class FlashingPlaceholderTextField: UITextField {
     
     // Stop animation when text field becomes first responder
     override func becomeFirstResponder() -> Bool {
-        isAnimating = false
         return super.becomeFirstResponder()
     }
     

--- a/nest-note/Common/Views/MiniEntryDetailView.swift
+++ b/nest-note/Common/Views/MiniEntryDetailView.swift
@@ -18,17 +18,10 @@ class MiniEntryDetailView: UIView {
     
     private let valueLabel: UILabel = {
         let label = UILabel()
-        label.font = .h3
+        label.font = .h4
+        label.textColor = .secondaryLabel
         label.translatesAutoresizingMaskIntoConstraints = false
         label.numberOfLines = 0
-        return label
-    }()
-    
-    private let visibilityLabel: UILabel = {
-        let label = UILabel()
-        label.font = .h4
-        label.text = "Comprehensive"  // Default text
-        label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()
     
@@ -60,7 +53,7 @@ class MiniEntryDetailView: UIView {
         layer.shadowRadius = 8
         
         // Disable user interaction on all subviews
-        [keyLabel, divider, valueLabel, visibilityLabel, timestampLabel].forEach { view in
+        [keyLabel, divider, valueLabel, timestampLabel].forEach { view in
             view.isUserInteractionEnabled = false
             addSubview(view)
         }
@@ -78,10 +71,7 @@ class MiniEntryDetailView: UIView {
             valueLabel.topAnchor.constraint(equalTo: divider.bottomAnchor, constant: 20),
             valueLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
             valueLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),
-            valueLabel.bottomAnchor.constraint(lessThanOrEqualTo: visibilityLabel.topAnchor, constant: -20),
-            
-            visibilityLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
-            visibilityLabel.bottomAnchor.constraint(equalTo: timestampLabel.topAnchor, constant: -4),
+            valueLabel.bottomAnchor.constraint(lessThanOrEqualTo: timestampLabel.topAnchor, constant: -20),
             
             timestampLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 20),
             timestampLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -20),

--- a/nest-note/Common/Views/MiniPlaceReviewView.swift
+++ b/nest-note/Common/Views/MiniPlaceReviewView.swift
@@ -1,0 +1,93 @@
+import UIKit
+
+final class MiniPlaceReviewView: UIView {
+    private let container = UIView()
+    private let thumbnailImageView = UIImageView()
+    private let aliasLabel = UILabel()
+    private let addressLabel = UILabel()
+    private let timestampLabel = UILabel()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+    
+    private func setup() {
+        backgroundColor = .secondarySystemGroupedBackground
+        layer.cornerRadius = 12
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.3
+        layer.shadowOffset = CGSize(width: 4, height: 8)
+        layer.shadowRadius = 8
+        
+        container.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(container)
+        
+        thumbnailImageView.translatesAutoresizingMaskIntoConstraints = false
+        thumbnailImageView.contentMode = .scaleAspectFill
+        thumbnailImageView.clipsToBounds = true
+        thumbnailImageView.layer.cornerRadius = 12
+        
+        aliasLabel.translatesAutoresizingMaskIntoConstraints = false
+        aliasLabel.font = .h3
+        aliasLabel.textColor = .label
+        
+        addressLabel.translatesAutoresizingMaskIntoConstraints = false
+        addressLabel.font = .bodyM
+        addressLabel.textColor = .secondaryLabel
+        addressLabel.numberOfLines = 2
+        
+        timestampLabel.translatesAutoresizingMaskIntoConstraints = false
+        timestampLabel.font = .bodyL
+        timestampLabel.textColor = .secondaryLabel
+        
+        [thumbnailImageView, aliasLabel, addressLabel, timestampLabel].forEach { container.addSubview($0) }
+        
+        NSLayoutConstraint.activate([
+            container.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+            container.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            container.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            container.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16),
+            
+            thumbnailImageView.topAnchor.constraint(equalTo: container.topAnchor),
+            thumbnailImageView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            thumbnailImageView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            thumbnailImageView.heightAnchor.constraint(equalTo: container.heightAnchor, multiplier: 0.55),
+            
+            aliasLabel.topAnchor.constraint(equalTo: thumbnailImageView.bottomAnchor, constant: 12),
+            aliasLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            aliasLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            
+            addressLabel.topAnchor.constraint(equalTo: aliasLabel.bottomAnchor, constant: 4),
+            addressLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            addressLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            
+            timestampLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            timestampLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            timestampLabel.bottomAnchor.constraint(equalTo: container.bottomAnchor)
+        ])
+    }
+    
+    func configure(with place: PlaceItem) {
+        aliasLabel.text = place.alias ?? place.title
+        addressLabel.text = place.address
+        timestampLabel.text = "Last modified: \(place.updatedAt.formatted(date: .abbreviated, time: .omitted))"
+        
+        Task {
+            do {
+                let image: UIImage
+                if let img = try? await NestService.shared.loadImages(for: place) {
+                    image = img
+                } else {
+                    image = UIImage(systemName: "mappin.circle") ?? UIImage()
+                }
+                await MainActor.run { self.thumbnailImageView.image = image }
+            }
+        }
+    }
+}

--- a/nest-note/Common/Views/MiniRoutineReviewView.swift
+++ b/nest-note/Common/Views/MiniRoutineReviewView.swift
@@ -1,0 +1,143 @@
+import UIKit
+
+final class MiniRoutineReviewView: UIView {
+    private let container = UIView()
+    private let iconImageView = UIImageView()
+    private let titleLabel = UILabel()
+    private let actionsStack = UIStackView()
+    private let timestampLabel = UILabel()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+    
+    private func setup() {
+        backgroundColor = .secondarySystemGroupedBackground
+        layer.cornerRadius = 12
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.3
+        layer.shadowOffset = CGSize(width: 4, height: 8)
+        layer.shadowRadius = 8
+        
+        container.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(container)
+        
+        iconImageView.translatesAutoresizingMaskIntoConstraints = false
+        iconImageView.contentMode = .scaleAspectFit
+        iconImageView.tintColor = .label
+        iconImageView.image = UIImage(systemName: "checklist")
+        
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.font = .h3
+        titleLabel.textColor = .label
+        titleLabel.numberOfLines = 2
+        
+        actionsStack.translatesAutoresizingMaskIntoConstraints = false
+        actionsStack.axis = .vertical
+        actionsStack.spacing = 12
+        
+        timestampLabel.translatesAutoresizingMaskIntoConstraints = false
+        timestampLabel.font = .bodyL
+        timestampLabel.textColor = .secondaryLabel
+        
+        [iconImageView, titleLabel, actionsStack, timestampLabel].forEach { container.addSubview($0) }
+        
+        NSLayoutConstraint.activate([
+            container.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+            container.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            container.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            container.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -16),
+            
+            iconImageView.topAnchor.constraint(equalTo: container.topAnchor),
+            iconImageView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            iconImageView.widthAnchor.constraint(equalToConstant: 24),
+            iconImageView.heightAnchor.constraint(equalToConstant: 24),
+            
+            titleLabel.centerYAnchor.constraint(equalTo: iconImageView.centerYAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 8),
+            titleLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            
+            actionsStack.topAnchor.constraint(equalTo: iconImageView.bottomAnchor, constant: 12),
+            actionsStack.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            actionsStack.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            
+            timestampLabel.topAnchor.constraint(greaterThanOrEqualTo: actionsStack.bottomAnchor, constant: 12),
+            timestampLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            timestampLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            timestampLabel.bottomAnchor.constraint(lessThanOrEqualTo: container.bottomAnchor)
+        ])
+    }
+    
+    func configure(with routine: RoutineItem) {
+        
+        let numberOfActionsToDisplay: Int = 5
+        
+        titleLabel.text = routine.title
+        timestampLabel.text = "Last modified: \(routine.updatedAt.formatted(date: .abbreviated, time: .omitted))"
+        
+        // Clear previous
+        actionsStack.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        
+        let previewActions = Array(routine.routineActions.prefix(numberOfActionsToDisplay))
+        for action in previewActions {
+            // Use a plain container view to avoid UIStackView alignment overriding our constraints
+            let row = UIView()
+            row.translatesAutoresizingMaskIntoConstraints = false
+            
+            let bullet = UIView()
+            bullet.translatesAutoresizingMaskIntoConstraints = false
+            bullet.backgroundColor = .tertiaryLabel
+            bullet.layer.cornerRadius = 4
+            
+            let label = UILabel()
+            label.translatesAutoresizingMaskIntoConstraints = false
+            label.font = .bodyXL
+            label.textColor = .secondaryLabel
+            label.text = action
+            label.numberOfLines = 2
+            label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+            
+            row.addSubview(bullet)
+            row.addSubview(label)
+            actionsStack.addArrangedSubview(row)
+            
+            let spacing: CGFloat = 12
+            let bulletSize: CGFloat = 8
+            let capOffset = -label.font.capHeight / 2.0
+            
+            NSLayoutConstraint.activate([
+                // Row should stretch horizontally within the stack
+                row.leadingAnchor.constraint(equalTo: actionsStack.leadingAnchor),
+                row.trailingAnchor.constraint(equalTo: actionsStack.trailingAnchor),
+                
+                // Bullet size and leading
+                bullet.leadingAnchor.constraint(equalTo: row.leadingAnchor),
+                bullet.widthAnchor.constraint(equalToConstant: bulletSize),
+                bullet.heightAnchor.constraint(equalToConstant: bulletSize),
+                
+                // Label placement
+                label.leadingAnchor.constraint(equalTo: bullet.trailingAnchor, constant: spacing),
+                label.topAnchor.constraint(equalTo: row.topAnchor),
+                label.trailingAnchor.constraint(equalTo: row.trailingAnchor),
+                label.bottomAnchor.constraint(lessThanOrEqualTo: row.bottomAnchor),
+                
+                // Align bullet center with the first text line center using cap-height
+                bullet.centerYAnchor.constraint(equalTo: label.firstBaselineAnchor, constant: capOffset)
+            ])
+        }
+        
+        if routine.routineActions.count > numberOfActionsToDisplay {
+            let more = UILabel()
+            more.font = .bodyS
+            more.textColor = .tertiaryLabel
+            more.text = "+\(routine.routineActions.count - numberOfActionsToDisplay) more"
+            actionsStack.addArrangedSubview(more)
+        }
+    }
+}

--- a/nest-note/Common/Views/NNEmptyStateView.swift
+++ b/nest-note/Common/Views/NNEmptyStateView.swift
@@ -2,6 +2,7 @@ import UIKit
 
 protocol NNEmptyStateViewDelegate: AnyObject {
     func emptyStateViewDidTapActionButton(_ emptyStateView: NNEmptyStateView)
+    func emptyStateView(_ emptyStateView: NNEmptyStateView, didTapActionWithTag tag: Int)
 }
 
 class NNEmptyStateView: UIView {
@@ -44,12 +45,23 @@ class NNEmptyStateView: UIView {
         return label
     }()
     
+    private lazy var buttonStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.spacing = 12
+        stack.distribution = .fillProportionally
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+    
+    private(set) var actionButtons: [NNSmallPrimaryButton] = []
+    
     private lazy var actionButton: NNSmallPrimaryButton = {
         let button = NNSmallPrimaryButton(title: "Test", backgroundColor: NNColors.primary.withAlphaComponent(0.15), foregroundColor: NNColors.primary)
         button.addTarget(self, action: #selector(actionButtonTapped), for: .touchUpInside)
-        //button.isHidden = true
-        button.translatesAutoresizingMaskIntoConstraints = false
         button.isUserInteractionEnabled = true
+        button.tag = 0
         return button
     }()
     
@@ -75,7 +87,8 @@ class NNEmptyStateView: UIView {
 
         stackView.addArrangedSubview(titleLabel)
         stackView.addArrangedSubview(subtitleLabel)
-        stackView.addArrangedSubview(actionButton)
+        stackView.addArrangedSubview(buttonStackView)
+        buttonStackView.addArrangedSubview(actionButton)
         
         stackView.setCustomSpacing(16, after: subtitleLabel)
         
@@ -93,7 +106,8 @@ class NNEmptyStateView: UIView {
             iconImageView.heightAnchor.constraint(equalToConstant: 48),
             iconImageView.widthAnchor.constraint(equalToConstant: 48),
             
-            actionButton.heightAnchor.constraint(equalToConstant: 46)
+            actionButton.heightAnchor.constraint(equalToConstant: 46),
+            buttonStackView.heightAnchor.constraint(equalToConstant: 46)
         ])
     }
     
@@ -125,5 +139,22 @@ class NNEmptyStateView: UIView {
     func addMenuToActionButton(menu: UIMenu) {
         actionButton.showsMenuAsPrimaryAction = true
         actionButton.menu = menu
+    }
+    
+    func addAction(title: String, backgroundColor: UIColor = NNColors.primary.withAlphaComponent(0.15), foregroundColor: UIColor = NNColors.primary, tag: Int) {
+        let button = NNSmallPrimaryButton(title: title, backgroundColor: backgroundColor, foregroundColor: foregroundColor)
+        button.addTarget(self, action: #selector(actionButtonWithTagTapped(_:)), for: .touchUpInside)
+        button.tag = tag
+        
+        actionButtons.append(button)
+        buttonStackView.addArrangedSubview(button)
+        
+        NSLayoutConstraint.activate([
+            button.heightAnchor.constraint(equalToConstant: 46)
+        ])
+    }
+    
+    @objc private func actionButtonWithTagTapped(_ sender: UIButton) {
+        delegate?.emptyStateView(self, didTapActionWithTag: sender.tag)
     }
 }

--- a/nest-note/Scenes/Home/OwnerHomeViewController.swift
+++ b/nest-note/Scenes/Home/OwnerHomeViewController.swift
@@ -526,8 +526,8 @@ final class OwnerHomeViewController: NNViewController, HomeViewControllerType, N
                     pinToEdge: .bottom,
                     offset: CGPoint(x: 0, y: 8)
                 )
-                return
             }
+            return // Always return after attempting to show this highest priority tip
         }
         
         // Priority 2: Your Nest tip (second priority)
@@ -550,8 +550,8 @@ final class OwnerHomeViewController: NNViewController, HomeViewControllerType, N
                     pinToEdge: .bottom,
                     offset: CGPoint(x: 0, y: 8)
                 )
-                return
             }
+            return // Always return after attempting to show this tip
         }
         
         // Priority 3: Current session tip (lower priority)
@@ -574,7 +574,6 @@ final class OwnerHomeViewController: NNViewController, HomeViewControllerType, N
                     pinToEdge: .bottom,
                     offset: CGPoint(x: 0, y: 8)
                 )
-                return
             }
         }
     }

--- a/nest-note/Scenes/Home/OwnerHomeViewController.swift
+++ b/nest-note/Scenes/Home/OwnerHomeViewController.swift
@@ -329,7 +329,7 @@ final class OwnerHomeViewController: NNViewController, HomeViewControllerType, N
                         // Add the setup progress section only if we should show setup
                         var updatedSnapshot = snapshot
                         updatedSnapshot.appendSections([.setupProgress])
-                        updatedSnapshot.appendItems([.setupProgress(current: setupProgress, total: 7)], toSection: .setupProgress)
+                        updatedSnapshot.appendItems([.setupProgress(current: setupProgress, total: 6)], toSection: .setupProgress)
                         snapshot = updatedSnapshot
                     }
                     

--- a/nest-note/Scenes/Home/SitterHomeViewController.swift
+++ b/nest-note/Scenes/Home/SitterHomeViewController.swift
@@ -759,6 +759,10 @@ extension SitterHomeViewController: UICollectionViewDelegate {
 }
 
 extension SitterHomeViewController: NNEmptyStateViewDelegate {
+    func emptyStateView(_ emptyStateView: NNEmptyStateView, didTapActionWithTag tag: Int) {
+        //
+    }
+    
     func emptyStateViewDidTapActionButton(_ emptyStateView: NNEmptyStateView) {
         let joinVC = JoinSessionViewController()
         joinVC.delegate = self

--- a/nest-note/Scenes/Nest/EntryDetailViewController.swift
+++ b/nest-note/Scenes/Nest/EntryDetailViewController.swift
@@ -110,8 +110,6 @@ final class EntryDetailViewController: NNSheetViewController, NNTippable {
         }
     }
     
-    
-    
     // MARK: - Setup Methods
     override func addContentToContainer() {
         super.addContentToContainer()
@@ -336,7 +334,7 @@ final class EntryDetailViewController: NNSheetViewController, NNTippable {
     
     func showTips() {
         // Show tips in priority order - only show one at a time
-        guard entry == nil && !isReadOnly else {
+        guard entry == nil && !isReadOnly && titleField.text == nil else {
             return
         }
         

--- a/nest-note/Scenes/Places/PlaceListViewController.swift
+++ b/nest-note/Scenes/Places/PlaceListViewController.swift
@@ -534,6 +534,10 @@ extension PlaceListViewController: TemporaryPlaceSelectionDelegate {
 }
 
 extension PlaceListViewController: NNEmptyStateViewDelegate {
+    func emptyStateView(_ emptyStateView: NNEmptyStateView, didTapActionWithTag tag: Int) {
+        //
+    }
+    
     func emptyStateViewDidTapActionButton(_ emptyStateView: NNEmptyStateView) {
         
         // Use the same action as the add button

--- a/nest-note/Scenes/Sessions/EditSessionViewController.swift
+++ b/nest-note/Scenes/Sessions/EditSessionViewController.swift
@@ -44,13 +44,21 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
     // 4 day, multi-day session by default
     private var initialDate: (startDate: Date, endDate: Date, isMultiDay: Bool) = (startDate: Date().roundedToNextHour(), endDate: Date().addingTimeInterval(60 * 60 * 96).roundedToNextHour(), isMultiDay: true)
     
-    private let titleTextField: UITextField = {
-        let field = UITextField()
-        field.placeholder = "Session Title"
+    private let titleTextField: FlashingPlaceholderTextField = {
+        let placeholders = [
+            "Date Night",
+            "Weekend Getaway", 
+            "Anniversary Trip",
+            "Birthday Trip",
+            "Family Vacation",
+            "Business Trip",
+            "Sleepover",
+            "Evening Out"
+        ]
+        let field = FlashingPlaceholderTextField(placeholders: placeholders)
         field.font = .h2
         field.borderStyle = .none
         field.returnKeyType = .done
-        field.placeholder = "Session Title"
         return field
     }()
     
@@ -660,10 +668,13 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
         Task {
             do {
                 // Validate required fields
-                guard let title = titleTextField.text, !title.isEmpty else {
+                guard let titleText = titleTextField.text, !titleText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                     showToast(text: "Please enter a session title", sentiment: .negative)
                     return
                 }
+                
+                // Trim whitespace from title
+                let title = titleText.trimmingCharacters(in: .whitespacesAndNewlines)
                 
                 guard let dateItem = dataSource.snapshot().itemIdentifiers(inSection: .date).first,
                       case let .dateSelection(startDate, endDate, isMultiDay) = dateItem else {

--- a/nest-note/Scenes/Sessions/EditSessionViewController.swift
+++ b/nest-note/Scenes/Sessions/EditSessionViewController.swift
@@ -51,8 +51,7 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
             "Anniversary Trip",
             "Birthday Trip",
             "Family Vacation",
-            "Business Trip",
-            "Sleepover",
+            "Sleepover w/ Grandma",
             "Evening Out"
         ]
         let field = FlashingPlaceholderTextField(placeholders: placeholders)

--- a/nest-note/Scenes/Sessions/ViewControllers/SessionCalendarViewController.swift
+++ b/nest-note/Scenes/Sessions/ViewControllers/SessionCalendarViewController.swift
@@ -294,9 +294,17 @@ final class SessionCalendarViewController: NNViewController, CollectionViewLoada
             case .events(let date):
                 headerView.configure(title: dateFormatter.string(from: date))
             case .emptyDays(let dateRange):
-                let startStr = dateFormatter.string(from: dateRange.start)
-                let endStr = dateFormatter.string(from: dateRange.end)
-                headerView.configure(title: "\(startStr) - \(endStr)")
+                let calendar = Calendar.current
+                if calendar.isDate(dateRange.start, inSameDayAs: dateRange.end) {
+                    // Single day
+                    let dayStr = dateFormatter.string(from: dateRange.start)
+                    headerView.configure(title: dayStr)
+                } else {
+                    // Date range
+                    let startStr = dateFormatter.string(from: dateRange.start)
+                    let endStr = dateFormatter.string(from: dateRange.end)
+                    headerView.configure(title: "\(startStr) - \(endStr)")
+                }
             }
         }
         
@@ -332,7 +340,8 @@ final class SessionCalendarViewController: NNViewController, CollectionViewLoada
             if let events = eventsByDate[currentDate], !events.isEmpty {
                 // If we had empty days, add them as a section
                 if let start = emptyDaysStart {
-                    let emptyRange = DateInterval(start: start, end: currentDate)
+                    let previousDay = calendar.date(byAdding: .day, value: -1, to: currentDate)!
+                    let emptyRange = DateInterval(start: start, end: previousDay)
                     snapshot.appendSections([.emptyDays(dateRange: emptyRange)])
                     snapshot.appendItems([EmptyDaysItem(dateRange: emptyRange)])
                     emptyDaysStart = nil
@@ -354,7 +363,7 @@ final class SessionCalendarViewController: NNViewController, CollectionViewLoada
         
         // Add any remaining empty days
         if let start = emptyDaysStart {
-            let emptyRange = DateInterval(start: start, end: calendar.date(byAdding: .day, value: 1, to: endDate)!)
+            let emptyRange = DateInterval(start: start, end: endDate)
             snapshot.appendSections([.emptyDays(dateRange: emptyRange)])
             snapshot.appendItems([EmptyDaysItem(dateRange: emptyRange)])
         }

--- a/nest-note/Scenes/Settings/SettingsViewController.swift
+++ b/nest-note/Scenes/Settings/SettingsViewController.swift
@@ -386,6 +386,7 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
             ("Test Place List", "list.star"),
             ("Test Place Map", "map.fill"),
             ("Test Invite Card", "rectangle.stack.badge.person.crop"),
+            ("Test Invite Card Animation", "rectangle.portrait.inset.filled"),
             ("Toast Test", "text.bubble.fill"),
             ("Test Schedule View", "calendar.day.timeline.left"),
             ("Test Routine Detail", "list.bullet.clipboard"),
@@ -491,6 +492,9 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
             navigationController?.pushViewController(viewController, animated: true)
         case "Test Invite Card":
             let vc = InviteCardDebugViewController()
+            navigationController?.pushViewController(vc, animated: true)
+        case "Test Invite Card Animation":
+            let vc = InviteCardAnimationDebugViewController()
             navigationController?.pushViewController(vc, animated: true)
         case "Toast Test":
             let vc = ToastTestViewController()

--- a/nest-note/Scenes/Settings/ViewControllers/EntryReviewViewController.swift
+++ b/nest-note/Scenes/Settings/ViewControllers/EntryReviewViewController.swift
@@ -17,6 +17,8 @@ class EntryReviewViewController: NNViewController, CardStackViewDelegate {
     // Add delegate property
     weak var reviewDelegate: EntryReviewViewControllerDelegate?
     
+    private let outOfDateThreshold: Int = 90
+    
     private let cardStackView: CardStackView = {
         let stack = CardStackView()
         stack.translatesAutoresizingMaskIntoConstraints = false
@@ -201,13 +203,12 @@ class EntryReviewViewController: NNViewController, CardStackViewDelegate {
         Task {
             do {
                 isLoading = true
-                // Threshold (reduced for testing to include recent items)
-                let days = 1
+                
                 let calendar = Calendar.current
-                let threshold = calendar.date(byAdding: .day, value: -days, to: Date()) ?? Date()
+                let threshold = calendar.date(byAdding: .day, value: -outOfDateThreshold, to: Date()) ?? Date()
 
                 // Gather items: entries via protocol, places and routines via repository services
-                let entries = try await entryRepository.fetchOutdatedEntries(olderThan: days)
+                let entries = try await entryRepository.fetchOutdatedEntries(olderThan: outOfDateThreshold)
                 var places: [PlaceItem] = []
                 var routines: [RoutineItem] = []
                 

--- a/nest-note/Scenes/Setup/StickyOwnerSetupFlowViewController.swift
+++ b/nest-note/Scenes/Setup/StickyOwnerSetupFlowViewController.swift
@@ -176,10 +176,6 @@ final class StickyOwnerSetupFlowViewController: NNViewController, PaywallPresent
             // Navigate to create an entry
             presentAddFirstEntry()
             
-        case .addFirstPlace:
-            // Navigate to add a place
-            presentAddFirstPlace()
-            
         case .enableNotifications:
             // Request notification permissions
             requestNotifications()
@@ -223,9 +219,9 @@ final class StickyOwnerSetupFlowViewController: NNViewController, PaywallPresent
             self?.delegate?.setupFlowDidUpdateStepStatus()
             
             // Dismiss the presented NestCategoryViewController
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) {
                 self?.presentedViewController?.dismiss(animated: true) {
-                    self?.showToast(delay: 0.0, text: "First Entry Added!", subtitle: "Here's to many more! 🥂", sentiment: .positive)                    
+                    self?.showToast(delay: 0.0, text: "First Item Added!", subtitle: "Here's to many more! 🥂", sentiment: .positive)
                 }
             }
             
@@ -233,40 +229,6 @@ final class StickyOwnerSetupFlowViewController: NNViewController, PaywallPresent
             if let entryObserver = self?.entryObserver {
                 NotificationCenter.default.removeObserver(entryObserver)
                 self?.entryObserver = nil
-            }
-        }
-    }
-    
-    private func presentAddFirstPlace() {
-        // Create a PlaceListViewController for adding a place
-        let placeListVC = PlaceListViewController()
-        
-        // Wrap in a navigation controller for proper presentation
-        let navController = UINavigationController(rootViewController: placeListVC)
-        
-        // Present the view controller
-        present(navController, animated: true)
-        
-        // Add observer to mark step as complete when a place is saved
-        placeObserver = NotificationCenter.default.addObserver(
-            forName: .placeDidSave,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            self?.setupService.markStepComplete(.addFirstPlace)
-            self?.delegate?.setupFlowDidUpdateStepStatus()
-            
-            // Dismiss the presented PlaceListViewController
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-                self?.presentedViewController?.dismiss(animated: true) {
-                    self?.showToast(delay: 0.0, text: "First Place Added!", subtitle: "You can never have too many!", sentiment: .positive)
-                }
-            }
-            
-            // Remove the observer after the step is completed
-            if let placeObserver = self?.placeObserver {
-                NotificationCenter.default.removeObserver(placeObserver)
-                self?.placeObserver = nil
             }
         }
     }

--- a/nest-note/Scenes/Sitters/ViewControllers/InviteCardAnimationDebugViewController.swift
+++ b/nest-note/Scenes/Sitters/ViewControllers/InviteCardAnimationDebugViewController.swift
@@ -1,0 +1,162 @@
+//
+//  InviteCardAnimationDebugViewController.swift
+//  nest-note
+//
+//  Created by Colton Swapp on 3/5/25.
+//
+
+import UIKit
+
+class InviteCardAnimationDebugViewController: NNViewController {
+    
+    private let inviteCard: SessionInviteCardView = {
+        let card = SessionInviteCardView()
+        card.translatesAutoresizingMaskIntoConstraints = false
+        card.alpha = 0 // Start hidden
+        return card
+    }()
+    
+    private let buttonStack: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .horizontal
+        stack.spacing = 8
+        return stack
+    }()
+    
+    private let animateButton: NNSmallPrimaryButton = {
+        let button = NNSmallPrimaryButton(title: "Animate", backgroundColor: .systemBlue.withAlphaComponent(0.2), foregroundColor: .systemBlue)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    private let resetButton: NNSmallPrimaryButton = {
+        let button = NNSmallPrimaryButton(title: "Reset", backgroundColor: .systemRed.withAlphaComponent(0.2), foregroundColor: .systemRed)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
+    private var inviteCardTopConstraint: NSLayoutConstraint?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureWithDebugData()
+        resetCardPosition()
+        setupActions()
+    }
+    
+    override func setup() {
+        title = "Invite Card Animation"
+        view.backgroundColor = .systemBackground
+    }
+    
+    override func addSubviews() {
+        
+        [inviteCard, buttonStack].forEach {
+            view.addSubview($0)
+        }
+        
+        buttonStack.addArrangedSubview(animateButton)
+        buttonStack.addArrangedSubview(resetButton)
+    }
+    
+    override func constrainSubviews() {
+        NSLayoutConstraint.activate([
+            
+            // Invite card
+            inviteCard.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            inviteCard.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            inviteCard.heightAnchor.constraint(equalToConstant: 400),
+            
+            // Buttons
+             buttonStack.leadingAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+             buttonStack.trailingAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+             buttonStack.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+             buttonStack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 40),
+            
+            animateButton.heightAnchor.constraint(equalToConstant: 46),
+            resetButton.heightAnchor.constraint(equalToConstant: 46)
+        ])
+        
+        // Set initial top constraint for invite card (off-screen)
+        inviteCardTopConstraint = inviteCard.topAnchor.constraint(equalTo: view.bottomAnchor, constant: 20)
+        inviteCardTopConstraint?.isActive = true
+    }
+    
+    private func setupActions() {
+        animateButton.addTarget(self, action: #selector(animateButtonTapped), for: .touchUpInside)
+        resetButton.addTarget(self, action: #selector(resetButtonTapped), for: .touchUpInside)
+    }
+    
+    @objc private func animateButtonTapped() {
+        print("🎬 Animate button tapped")
+        animateInviteCard()
+    }
+    
+    @objc private func resetButtonTapped() {
+        resetCardPosition()
+    }
+    
+    private func animateInviteCard() {
+        print("🎬 Starting animation - current alpha: \(inviteCard.alpha)")
+        
+        // First make it visible
+        inviteCard.alpha = 1
+        
+        // Remove current constraint and add new one
+        inviteCardTopConstraint?.isActive = false
+        inviteCardTopConstraint = inviteCard.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 0)
+        inviteCardTopConstraint?.isActive = true
+        
+        print("🎬 Constraints updated, starting animation")
+        
+        // Animate it up from the bottom with spring effect
+        UIView.animate(withDuration: 0.6, delay: 0, usingSpringWithDamping: 0.8, initialSpringVelocity: 0.5) {
+            self.view.layoutIfNeeded()
+        } completion: { finished in
+            print("🎬 Animation completed: \(finished)")
+        }
+        
+        HapticsHelper.successHaptic()
+    }
+    
+    private func resetCardPosition() {
+        // Hide the card and reset position
+        inviteCard.alpha = 0
+        
+        // Remove current constraint and add new one (off-screen)
+        inviteCardTopConstraint?.isActive = false
+        inviteCardTopConstraint = inviteCard.topAnchor.constraint(equalTo: view.bottomAnchor, constant: 20)
+        inviteCardTopConstraint?.isActive = true
+        
+        // Immediately update layout
+        view.layoutIfNeeded()
+    }
+    
+    private func configureWithDebugData() {
+        // Create debug session
+        let now = Date()
+        let session = SessionItem(
+            title: "Weekend Getaway",
+            startDate: now.addingTimeInterval(24 * 60 * 60), // Tomorrow
+            endDate: now.addingTimeInterval(3 * 24 * 60 * 60), // 3 days from now
+            isMultiDay: true
+        )
+        
+        // Create debug invite
+        let invite = Invite(
+            id: "invite-123456",
+            nestID: "nest123",
+            nestName: "Swapp Nest",
+            sessionID: session.id,
+            sitterEmail: "test@example.com",
+            status: .pending,
+            createdAt: Date(),
+            expiresAt: Date().addingTimeInterval(48 * 60 * 60),
+            createdBy: "user123"
+        )
+        
+        // Configure card
+        inviteCard.configure(with: session, invite: invite)
+    }
+}

--- a/nest-note/Scenes/Sitters/ViewControllers/InviteCardDebugViewController.swift
+++ b/nest-note/Scenes/Sitters/ViewControllers/InviteCardDebugViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 
 class InviteCardDebugViewController: NNViewController {
     
+    // MARK: - UI
     private let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -16,15 +17,42 @@ class InviteCardDebugViewController: NNViewController {
         return stack
     }()
     
+    // Container for the card
+    private let cardContainer: UIView = {
+        let v = UIView()
+        v.translatesAutoresizingMaskIntoConstraints = false
+        v.layer.cornerRadius = 12
+        v.layer.masksToBounds = false
+        v.layer.shadowColor = UIColor.black.cgColor
+        v.layer.shadowOpacity = 0.25
+        v.layer.shadowOffset = CGSize(width: 0, height: 6)
+        v.layer.shadowRadius = 10
+        return v
+    }()
+
     private let inviteCard: SessionInviteCardView = {
         let card = SessionInviteCardView()
         card.translatesAutoresizingMaskIntoConstraints = false
+        card.layer.cornerRadius = 12
         return card
     }()
+
+    private var cardTopConstraint: NSLayoutConstraint?
+    private var cardCenterConstraint: NSLayoutConstraint?
+    private var hasAnimatedIn = false
     
     override func viewDidLoad() {
         super.viewDidLoad()
         configureWithDebugData()
+        setupNavButtons()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        if !hasAnimatedIn {
+            hasAnimatedIn = true
+            animateCardIntoCenter()
+        }
     }
     
     override func setup() {
@@ -35,8 +63,9 @@ class InviteCardDebugViewController: NNViewController {
         view.addSubview(scrollView)
         scrollView.addSubview(stackView)
         
-        // Add card at the top
-        stackView.addArrangedSubview(inviteCard)
+        // Add card container directly so we can animate constraints cleanly
+        view.addSubview(cardContainer)
+        cardContainer.addSubview(inviteCard)
     }
     
     override func constrainSubviews() {
@@ -52,8 +81,23 @@ class InviteCardDebugViewController: NNViewController {
             stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: -20),
             stackView.widthAnchor.constraint(equalTo: view.widthAnchor, constant: -40),
             
-            inviteCard.heightAnchor.constraint(equalToConstant: view.frame.height * 0.4)
+            // Scroll container constraints (kept for layout stability)
+            
+            // Card container initial constraints
+            cardContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            cardContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            cardContainer.heightAnchor.constraint(equalToConstant: view.frame.height * 0.45),
+            
+            inviteCard.topAnchor.constraint(equalTo: cardContainer.topAnchor),
+            inviteCard.leadingAnchor.constraint(equalTo: cardContainer.leadingAnchor),
+            inviteCard.trailingAnchor.constraint(equalTo: cardContainer.trailingAnchor),
+            inviteCard.bottomAnchor.constraint(equalTo: cardContainer.bottomAnchor)
         ])
+
+        // Off-screen start and resting center constraints
+        cardTopConstraint = cardContainer.topAnchor.constraint(equalTo: view.bottomAnchor, constant: 20)
+        cardTopConstraint?.isActive = true
+        cardCenterConstraint = cardContainer.centerYAnchor.constraint(equalTo: view.centerYAnchor)
     }
     
     private func configureWithDebugData() {
@@ -81,5 +125,37 @@ class InviteCardDebugViewController: NNViewController {
         
         // Configure card
         inviteCard.configure(with: session, invite: invite)
+    }
+
+    // MARK: - Actions
+    private func setupNavButtons() {
+        let flipButton = UIBarButtonItem(title: "Flip", style: .plain, target: self, action: #selector(flipTapped))
+        let resetButton = UIBarButtonItem(title: "Reset", style: .plain, target: self, action: #selector(resetTapped))
+        navigationItem.rightBarButtonItems = [flipButton, resetButton]
+    }
+    
+    @objc private func flipTapped() {
+        animateCardIntoCenter()
+    }
+    
+    @objc private func resetTapped() {
+        // Reset to offscreen
+        cardCenterConstraint?.isActive = false
+        cardTopConstraint?.isActive = true
+        view.layoutIfNeeded()
+    }
+
+    private func animateCardIntoCenter() {
+        // Ensure starting state
+        view.layoutIfNeeded()
+
+        // Move constraints to center
+        cardTopConstraint?.isActive = false
+        cardCenterConstraint?.isActive = true
+
+        // Simple slide animation
+        UIView.animate(withDuration: 0.75, delay: 0, usingSpringWithDamping: 0.85, initialSpringVelocity: 0.6, options: [.curveEaseOut]) {
+            self.view.layoutIfNeeded()
+        }
     }
 } 

--- a/nest-note/Scenes/Sitters/ViewControllers/JoinSessionViewController.swift
+++ b/nest-note/Scenes/Sitters/ViewControllers/JoinSessionViewController.swift
@@ -94,7 +94,7 @@ class JoinSessionViewController: NNViewController {
         view.alpha = 0 // Start hidden
         return view
     }()
-    
+
     private var inviteCardBottomConstraint: NSLayoutConstraint?
     
     private var currentInviteCode: String?
@@ -154,7 +154,7 @@ class JoinSessionViewController: NNViewController {
         NSLayoutConstraint.activate([
             inviteCardView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
             inviteCardView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
-            inviteCardView.heightAnchor.constraint(equalToConstant: view.frame.height * 0.4),
+            inviteCardView.heightAnchor.constraint(equalToConstant: view.frame.height * 0.5),
             inviteCardBottomConstraint!
         ])
     }

--- a/nest-note/Utilities/Services/SetupService.swift
+++ b/nest-note/Utilities/Services/SetupService.swift
@@ -6,7 +6,6 @@ enum SetupStepType: Int, CaseIterable {
     case createAccount = 0
     case setupNest = 1
     case addFirstEntry = 2
-    case addFirstPlace = 3
     case enableNotifications = 4
     case feedback = 5
     case finalStep = 6
@@ -18,9 +17,7 @@ enum SetupStepType: Int, CaseIterable {
         case .setupNest:
             return "Setup your Nest"
         case .addFirstEntry:
-            return "Add your first entry"
-        case .addFirstPlace:
-            return "Add your first place"
+            return "Explore Folders"
         case .enableNotifications:
             return "Enable Notifications"
         case .feedback:
@@ -37,9 +34,7 @@ enum SetupStepType: Int, CaseIterable {
         case .setupNest:
             return "Add a nest name and address."
         case .addFirstEntry:
-            return "Garage codes, wifi passwords, and other general information make great entries. These are what your sitter will see."
-        case .addFirstPlace:
-            return "Places are locations that would be important for sitters to know about. Grandma's house, favorite park, etc."
+            return "Folders contain information, important places, & routines"
         case .enableNotifications:
             return "Stay in the know."
         case .feedback:
@@ -228,10 +223,6 @@ final class SetupService {
             // Check if user has at least one entry
             // This would need to be implemented based on your data model
             return checkIfUserHasEntries()
-            
-        case .addFirstPlace:
-            // Check if user has at least one place
-            return true
             
         case .enableNotifications:
             // Check if user has enabled notifications


### PR DESCRIPTION
- Fixed tips shown on `OwnerHome`
- Made all items (including routines & places) reviewable via the `EntryReviewViewController`
- Resolved some `SessionCalendarView` bugs
- Enhanced the `Finish Setting Up` flow to account for some new functionality
- Replaced `EditSessionViewController` titleField with a `flashing placeholder` variant to draw more attention to the title of the session
- Redesigned the `SessionInviteCard` to be more special & aesthetic

<img height="500" alt="Simulator Screenshot - iPhone 16 Pro (18 5) - 2025-08-14 at 17 20 21" src="https://github.com/user-attachments/assets/ab265c30-1e98-4a28-b7b1-27c2b4f45811" />
<img height="500" alt="Simulator Screenshot - iPhone 16 (18 1) - 2025-08-13 at 09 56 11" src="https://github.com/user-attachments/assets/8c891e33-ece7-46f5-aa19-870945ad6ade" />
<img height="500" alt="Simulator Screenshot - iPhone 16 (18 1) - 2025-08-13 at 09 55 59" src="https://github.com/user-attachments/assets/d1fc65de-2945-4397-b834-72ac4098d547" />


https://github.com/user-attachments/assets/fec68786-c375-489c-a672-7e10ab27db54


