### PR TITLE
closes swa-97, swa-98

### DIFF
--- a/nest-note/Scenes/Home/OwnerHomeViewController.swift
+++ b/nest-note/Scenes/Home/OwnerHomeViewController.swift
@@ -177,7 +177,7 @@ final class OwnerHomeViewController: NNViewController, HomeViewControllerType, N
                 // Get sitter name or email
                 let sitterInfo: String? = session.assignedSitter?.name ?? session.assignedSitter?.email
                 
-                let durationText: String = sitterInfo == nil ? "No sitter assigned • \(duration)" : "\(sitterInfo!) • \(duration)"
+                let durationText: String = sitterInfo == nil ? duration : "\(sitterInfo!) • \(duration)"
                 
                 cell.configure(title: session.title, duration: durationText)
                 

--- a/nest-note/Scenes/Home/Views/CurrentSessionCell.swift
+++ b/nest-note/Scenes/Home/Views/CurrentSessionCell.swift
@@ -92,4 +92,9 @@ final class CurrentSessionCell: UICollectionViewListCell {
         titleLabel.text = title
         durationLabel.text = duration
     }
+    
+    func configureForEarlyAccess(title: String, sessionStartTime: String) {
+        titleLabel.text = title
+        durationLabel.text = "Session starts \(sessionStartTime)"
+    }
 } 

--- a/nest-note/Services/SitterViewService.swift
+++ b/nest-note/Services/SitterViewService.swift
@@ -379,7 +379,7 @@ final class SitterViewService: EntryRepository {
                     return
                 }
                 session = fetchedSession
-                Logger.log(level: .debug, category: .sitterViewService, message: "Successfully fetched session: \(session.id)")
+                Logger.log(level: .debug, category: .sitterViewService, message: "Successfully fetched session: \(session.id) with status: \(session.status)")
             } catch {
                 Logger.log(level: .error, category: .sitterViewService, message: "Failed to fetch in-progress session: \(error.localizedDescription)")
                 await MainActor.run {


### PR DESCRIPTION
- Fixed a bug on the `OwnerHomeViewController` where if no sitter was associated with a session, we'd have an orphaned `bullet` before the date label
- Resolved an issue where `Early Access` sessions were confusing to access.

<img height="500" alt="Simulator Screenshot - iPhone 16 Pro (18 5) - 2025-08-15 at 15 16 00" src="https://github.com/user-attachments/assets/603e2598-73fe-4aff-bcb9-01d2b3eb48ea" />
