### PR TITLE
Fix hide events section for pdf export

### DIFF
--- a/nest-note/Services/PDFExportService.swift
+++ b/nest-note/Services/PDFExportService.swift
@@ -113,7 +113,23 @@ class PDFExportService {
             currentY += 30
             
             // Use the provided section order or default
-            let sectionsToRender = sectionOrder ?? defaultSectionOrder
+            let requestedSections = sectionOrder ?? defaultSectionOrder
+            
+            // Filter out sections that have no content
+            let sectionsToRender = requestedSections.filter { section in
+                switch section {
+                case .events:
+                    return !events.isEmpty
+                case .entries:
+                    return !filteredEntriesForEntriesSection.isEmpty || !filteredPlacesForEntriesSection.isEmpty || !filteredRoutinesForSection.isEmpty
+                case .contacts:
+                    return true // Always show contacts section for now
+                case .places:
+                    return !filteredPlacesForEntriesSection.isEmpty
+                case .routines:
+                    return !filteredRoutinesForSection.isEmpty
+                }
+            }
             
             // Draw sections in the specified order
             for (index, section) in sectionsToRender.enumerated() {


### PR DESCRIPTION
Filter out empty sections in PDF export to prevent unnecessary headers from appearing when there is no content.

---
<a href="https://cursor.com/background-agent?bcId=bc-3355f29f-3fc5-4841-8219-71729e67e3ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3355f29f-3fc5-4841-8219-71729e67e3ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

