### PR TITLE
Remove tooltip from NestCategoryViewController

### DIFF
--- a/nest-note/Common/Utilities/NNTipModel.swift
+++ b/nest-note/Common/Utilities/NNTipModel.swift
@@ -58,15 +58,7 @@ enum EntryDetailTips {
     )
 }
 
-enum NestCategoryTips {
 
-    static let entrySuggestionTip = NNTipModel(
-        id: "EntrySuggestionTip",
-        title: "Need Inspiration?",
-        message: "Browse our collection of item suggestions.",
-        systemImageName: "sparkles"
-    )
-}
 
 enum OwnerHomeTips {
     

--- a/nest-note/Scenes/Nest/NestCategoryViewController.swift
+++ b/nest-note/Scenes/Nest/NestCategoryViewController.swift
@@ -10,7 +10,7 @@ import RevenueCat
 import RevenueCatUI
 import CoreLocation
 
-class NestCategoryViewController: NNViewController, NestLoadable, CollectionViewLoadable, PaywallPresentable, PaywallViewControllerDelegate, NNTippable, PlaceListViewControllerDelegate {
+class NestCategoryViewController: NNViewController, NestLoadable, CollectionViewLoadable, PaywallPresentable, PaywallViewControllerDelegate, PlaceListViewControllerDelegate {
     // MARK: - Properties
     internal let entryRepository: EntryRepository
     private let category: String
@@ -1295,9 +1295,6 @@ class NestCategoryViewController: NNViewController, NestLoadable, CollectionView
     }
     
     private func showItemSuggestions() {
-        // Dismiss the suggestion tip when user opens suggestions
-        NNTipManager.shared.dismissTip(NestCategoryTips.entrySuggestionTip)
-
         // Present CommonItemsViewController as a sheet with medium and large detents
         let commonItemsVC = CommonItemsViewController(category: category, entryRepository: entryRepository)
         commonItemsVC.delegate = self
@@ -1473,29 +1470,7 @@ class NestCategoryViewController: NNViewController, NestLoadable, CollectionView
         addEntryButton.alpha = hasSelection ? 1.0 : 0.6
     }
     
-    func showTips() {
-        // Only show tips for nest owners
-        guard entryRepository is NestService else { return }
-        
-        trackScreenVisit()
-        
-        // Show suggestion tip for nest owners and if the menu button exists
-        if let suggestionsButton = emptyStateView.actionButtons.first(where: { $0.tag == 1 }),
-           NNTipManager.shared.shouldShowTip(NestCategoryTips.entrySuggestionTip) {
-            
-            // Show the tooltip anchored to the navigation bar menu button
-            // Using .bottom edge to show tooltip below the navigation bar
-            guard !(navigationController?.navigationBar.prefersLargeTitles ?? false) else { return }
-            
-            NNTipManager.shared.showTip(
-                NestCategoryTips.entrySuggestionTip,
-                sourceView: suggestionsButton,
-                in: self,
-                pinToEdge: .bottom,
-                offset: CGPoint(x: 0, y: 8)
-            )
-        }
-    }
+
     
     private func flashCell(for entry: BaseEntry) {
         guard let indexPath = dataSource?.indexPath(for: entry),


### PR DESCRIPTION
Remove all tip functionality from `NestCategoryViewController` and the unused `NestCategoryTips` enum to resolve a broken tooltip issue (SWA-108).

The Linear issue SWA-108 reported a "Broken ToolTip; 'Entries Live Here'" on `NestCategoryViewController`. Although the specific "Entries Live Here" tip was no longer present, the request was to remove "the Tip" entirely. This PR removes all related tip functionality, including `NNTippable` conformance and the `showTips()` method, and cleans up the now-unused `NestCategoryTips` enum.

---
Linear Issue: [SWA-108](https://linear.app/swappfunc/issue/SWA-108/broken-tooltip-entries-live-here)

<a href="https://cursor.com/background-agent?bcId=bc-f9369bb5-a4b2-4d20-9b13-263696862937">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f9369bb5-a4b2-4d20-9b13-263696862937">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

