### PR TITLE
Fix owner home bullet display when no sitter

### DIFF
--- a/nest-note/Scenes/Home/OwnerHomeViewController.swift
+++ b/nest-note/Scenes/Home/OwnerHomeViewController.swift
@@ -174,8 +174,15 @@ final class OwnerHomeViewController: NNViewController, HomeViewControllerType, N
                 formatter.timeStyle = .none
                 let duration = formatter.string(from: session.startDate, to: session.endDate)
                 
-                // Get sitter name or email
-                let sitterInfo: String? = session.assignedSitter?.name ?? session.assignedSitter?.email
+                // Get sitter name or email, ensuring it's not empty or whitespace-only
+                let sitterInfo: String? = {
+                    if let name = session.assignedSitter?.name, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        return name
+                    } else if let email = session.assignedSitter?.email, !email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        return email
+                    }
+                    return nil
+                }()
                 
                 let durationText: String = sitterInfo == nil ? duration : "\(sitterInfo!) • \(duration)"
                 

--- a/nest-note/Scenes/Home/Views/HomeSessionCell.swift
+++ b/nest-note/Scenes/Home/Views/HomeSessionCell.swift
@@ -165,7 +165,14 @@ final class HomeSessionCell: UICollectionViewListCell {
         titleLabel.text = session.title
         
         if let sitter = session.assignedSitter {
-            subtitleLabel.text = sitter.name
+            let sitterName = sitter.name.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !sitterName.isEmpty {
+                subtitleLabel.text = sitterName
+            } else {
+                // If name is empty, try email
+                let sitterEmail = sitter.email.trimmingCharacters(in: .whitespacesAndNewlines)
+                subtitleLabel.text = !sitterEmail.isEmpty ? sitterEmail : "No sitter assigned"
+            }
         } else {
             subtitleLabel.text = "No sitter assigned"
         }


### PR DESCRIPTION
Hide the bullet point in `OwnerHome` and correctly display sitter info in `HomeSessionCell` when no valid sitter name or email is present.

The previous implementation for `sitterInfo` in `OwnerHomeViewController` only checked for `nil`, not empty strings, causing the bullet to appear incorrectly. Similarly, `HomeSessionCell` directly used `sitter.name` without validating if it was empty, leading to blank subtitles instead of "No sitter assigned" or falling back to email. This PR ensures that empty or whitespace-only strings are properly handled.

---
Linear Issue: [SWA-97](https://linear.app/swappfunc/issue/SWA-97/fix-ownerhome-currentsession-with-no-sitter)

<a href="https://cursor.com/background-agent?bcId=bc-7f7a6f0b-cf50-447a-89e9-063b7976384e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f7a6f0b-cf50-447a-89e9-063b7976384e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

