### PR TITLE
Fix ownerhome bullet display when no sitter

### DIFF
--- a/nest-note/Scenes/Home/OwnerHomeViewController.swift
+++ b/nest-note/Scenes/Home/OwnerHomeViewController.swift
@@ -174,8 +174,19 @@ final class OwnerHomeViewController: NNViewController, HomeViewControllerType, N
                 formatter.timeStyle = .none
                 let duration = formatter.string(from: session.startDate, to: session.endDate)
                 
-                // Get sitter name or email
-                let sitterInfo: String? = session.assignedSitter?.name ?? session.assignedSitter?.email
+                // Get sitter name or email, but only if they're not empty strings
+                let sitterName = session.assignedSitter?.name.trimmingCharacters(in: .whitespacesAndNewlines)
+                let sitterEmail = session.assignedSitter?.email.trimmingCharacters(in: .whitespacesAndNewlines)
+                
+                let sitterInfo: String? = {
+                    if let name = sitterName, !name.isEmpty {
+                        return name
+                    } else if let email = sitterEmail, !email.isEmpty {
+                        return email
+                    } else {
+                        return nil
+                    }
+                }()
                 
                 let durationText: String = sitterInfo == nil ? duration : "\(sitterInfo!) • \(duration)"
                 


### PR DESCRIPTION
Fix `OwnerHome` currentSession displaying a bullet when no sitter is assigned.

Previously, the bullet would show if `session.assignedSitter` existed but had empty strings for `name` and `email` (e.g., for open invites). The old logic only checked for `nil`, but an empty string is not `nil`, causing the bullet to appear. The updated logic now explicitly checks if the `sitterName` or `sitterEmail` are non-empty after trimming whitespace, ensuring the bullet only appears when meaningful sitter information is present.

---
Linear Issue: [SWA-97](https://linear.app/swappfunc/issue/SWA-97/fix-ownerhome-currentsession-with-no-sitter)

<a href="https://cursor.com/background-agent?bcId=bc-ffa33de4-d161-4c4b-a277-3ba4b42e426c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ffa33de4-d161-4c4b-a277-3ba4b42e426c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

