### PR TITLE
Disable save/update button if no changes

### DIFF
--- a/nest-note/Scenes/Nest/EntryDetailViewController.swift
+++ b/nest-note/Scenes/Nest/EntryDetailViewController.swift
@@ -59,6 +59,17 @@ final class EntryDetailViewController: NNSheetViewController, NNTippable {
     let entry: BaseEntry?
     private let category: String
     
+    // Track original values for change detection
+    private var originalTitle: String?
+    private var originalContent: String?
+    
+    // Track changes
+    private var hasUnsavedChanges: Bool = false {
+        didSet {
+            updateSaveButtonState()
+        }
+    }
+    
     // MARK: - Initialization
     init(category: String, entry: BaseEntry? = nil, sourceFrame: CGRect? = nil, isReadOnly: Bool = false) {
         self.category = category
@@ -92,6 +103,13 @@ final class EntryDetailViewController: NNSheetViewController, NNTippable {
         contentTextView.text = entry?.content
         contentTextView.delegate = self
         
+        // Store original values for change detection
+        originalTitle = entry?.title
+        originalContent = entry?.content
+        
+        // Add target for title field changes
+        titleField.addTarget(self, action: #selector(titleFieldChanged), for: .editingChanged)
+        
         // Configure folder label with last 2 components
         configureFolderLabel()
         
@@ -108,6 +126,9 @@ final class EntryDetailViewController: NNSheetViewController, NNTippable {
         } else if entry == nil && !isReadOnly {
             contentTextView.becomeFirstResponder()
         }
+        
+        // Initial save button state update
+        updateSaveButtonState()
     }
     
     // MARK: - Setup Methods
@@ -367,6 +388,45 @@ final class EntryDetailViewController: NNSheetViewController, NNTippable {
         }
     }
     
+    // MARK: - Change Detection
+    
+    @objc private func titleFieldChanged() {
+        checkForUnsavedChanges()
+    }
+    
+    private func checkForUnsavedChanges() {
+        let currentTitle = titleField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let currentContent = contentTextView.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        let titleChanged = currentTitle != originalTitle
+        let contentChanged = currentContent != originalContent
+        
+        hasUnsavedChanges = titleChanged || contentChanged
+    }
+    
+    private func updateSaveButtonState() {
+        if isReadOnly {
+            saveButton.isHidden = true
+            return
+        }
+        
+        // For new entries, enable save button when title and content are not empty
+        if entry == nil {
+            let titleString = titleField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let contentString = contentTextView.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let hasRequiredContent = !titleString.isEmpty && !contentString.isEmpty
+            saveButton.isEnabled = hasRequiredContent
+            return
+        }
+        
+        // For existing entries, enable save button only when there are changes
+        let titleString = titleField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let contentString = contentTextView.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let hasRequiredContent = !titleString.isEmpty && !contentString.isEmpty
+        
+        saveButton.isEnabled = hasRequiredContent && hasUnsavedChanges
+    }
+    
     // MARK: - Error Handling
     
     private func showErrorAlert(message: String) {
@@ -396,6 +456,10 @@ extension EntryDetailViewController: UITextFieldDelegate {
 extension EntryDetailViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         //
+    }
+    
+    func textViewDidChange(_ textView: UITextView) {
+        checkForUnsavedChanges()
     }
     
     func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {


### PR DESCRIPTION
Implements save/update button disablement for `EntryDetailViewController` and initiates change tracking for `SessionEventViewController` to address SWA-109.

`EntryDetailViewController` now fully disables its save button until changes are detected and valid content is present. For `SessionEventViewController`, properties and callbacks for change detection have been added, but the core `checkForUnsavedChanges()` and `updateSaveButtonState()` methods still need to be implemented to complete the functionality.

---
Linear Issue: [SWA-109](https://linear.app/swappfunc/issue/SWA-109/disable-saveupdate-button-if-no-changes)

<a href="https://cursor.com/background-agent?bcId=bc-fc0a1dd0-b509-47c0-8aaf-6e68a761d443">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc0a1dd0-b509-47c0-8aaf-6e68a761d443">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

