### PR TITLE
closes swa-111, swa-105, swa-106, swa-107, swa-97, swa-109, swa-110

### DIFF
--- a/nest-note.xcodeproj/project.pbxproj
+++ b/nest-note.xcodeproj/project.pbxproj
@@ -22,8 +22,6 @@
 		F670378D2DFCEA8E000D897E /* nn-storekit-config.storekit in Resources */ = {isa = PBXBuildFile; fileRef = F670378C2DFCEA8E000D897E /* nn-storekit-config.storekit */; };
 		F670378F2DFCEBC9000D897E /* StoreKitTestCertificate.cer in Resources */ = {isa = PBXBuildFile; fileRef = F670378E2DFCEBC9000D897E /* StoreKitTestCertificate.cer */; };
 		F6A81B902E56524600D24D95 /* QRCode in Frameworks */ = {isa = PBXBuildFile; productRef = F6A81B8F2E56524600D24D95 /* QRCode */; };
-		F6A81B922E56524600D24D95 /* QRCodeDetector in Frameworks */ = {isa = PBXBuildFile; productRef = F6A81B912E56524600D24D95 /* QRCodeDetector */; };
-		F6A81B952E56642A00D24D95 /* QRCodeDetector in Embed Frameworks */ = {isa = PBXBuildFile; productRef = F6A81B912E56524600D24D95 /* QRCodeDetector */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F6B6782A2CDDED5700FDCAE4 /* Toast in Frameworks */ = {isa = PBXBuildFile; productRef = F6B678292CDDED5700FDCAE4 /* Toast */; };
 		F6E9EE532DA596DF009113C6 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = F6E9EE522DA596DF009113C6 /* FirebaseMessaging */; };
 /* End PBXBuildFile section */
@@ -35,7 +33,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				F6A81B952E56642A00D24D95 /* QRCodeDetector in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 1;
@@ -81,7 +78,6 @@
 				F66E29242CD077E900B90ABC /* FirebaseAnalytics in Frameworks */,
 				F66E292A2CD077E900B90ABC /* FirebaseCrashlytics in Frameworks */,
 				F6A81B902E56524600D24D95 /* QRCode in Frameworks */,
-				F6A81B922E56524600D24D95 /* QRCodeDetector in Frameworks */,
 				F6B6782A2CDDED5700FDCAE4 /* Toast in Frameworks */,
 				F66E29302CD077E900B90ABC /* FirebaseRemoteConfig in Frameworks */,
 				F66E29282CD077E900B90ABC /* FirebaseCore in Frameworks */,
@@ -160,7 +156,6 @@
 				F670377E2DFCA5DD000D897E /* RevenueCat */,
 				F67037802DFCA5DD000D897E /* RevenueCatUI */,
 				F6A81B8F2E56524600D24D95 /* QRCode */,
-				F6A81B912E56524600D24D95 /* QRCodeDetector */,
 			);
 			productName = "nest-note";
 			productReference = F64DE3E92CB1C893006D21FC /* nest-note.app */;
@@ -563,11 +558,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = F6A81B8E2E56524600D24D95 /* XCRemoteSwiftPackageReference "qrcode" */;
 			productName = QRCode;
-		};
-		F6A81B912E56524600D24D95 /* QRCodeDetector */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F6A81B8E2E56524600D24D95 /* XCRemoteSwiftPackageReference "qrcode" */;
-			productName = QRCodeDetector;
 		};
 		F6B678292CDDED5700FDCAE4 /* Toast */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/nest-note/Common/Views/CardStackView.swift
+++ b/nest-note/Common/Views/CardStackView.swift
@@ -338,9 +338,9 @@ class CardStackView: UIView {
                 card.layer.zPosition = CGFloat(self.cards.count - index)
             }
             
-            // Show spinner if this is the last card
+            // Show empty state if this is the last card
             if isLastCard {
-                self.emptyStateView.alpha = 1
+                self.emptyStateView.animateIn()
             }
         }) { _ in
             cardToRemove.removeFromSuperview()
@@ -555,8 +555,8 @@ class CardStackView: UIView {
     private func showSuccessState() {
         UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut) {
             self.progressLabel.alpha = 0
-            self.emptyStateView.alpha = 1
         }
+        emptyStateView.animateIn()
     }
     
     // Add public method for programmatic right swipe
@@ -716,9 +716,7 @@ class CardStackView: UIView {
         )
         
         // Show empty state view with animation
-        UIView.animate(withDuration: 0.3) {
-            self.emptyStateView.alpha = 1.0
-        }
+        emptyStateView.animateIn()
         
         // Hide progress label
         progressLabel.alpha = 0

--- a/nest-note/Common/Views/NNDateTimeControl.swift
+++ b/nest-note/Common/Views/NNDateTimeControl.swift
@@ -27,6 +27,9 @@ final class NNDateTimeControl: UIStackView {
             // Always update timeText
             formatter.dateFormat = "h:mm a"
             timeText = formatter.string(from: date)
+            
+            // Call the date changed callback
+            onDateChanged?()
         }
     }
     
@@ -59,6 +62,7 @@ final class NNDateTimeControl: UIStackView {
     
     var onDateTapped: (() -> Void)?
     var onTimeTapped: (() -> Void)?
+    var onDateChanged: (() -> Void)?
     
     var dateText: String {
         get { dateControl.text }

--- a/nest-note/Common/Views/NNEmptyStateView+Animations.swift
+++ b/nest-note/Common/Views/NNEmptyStateView+Animations.swift
@@ -1,0 +1,127 @@
+//
+//  NNEmptyStateView+Animations.swift
+//  nest-note
+//
+//  Created by Claude on 8/24/25.
+//
+
+import UIKit
+
+extension NNEmptyStateView {
+    
+    /// Animates the empty state view into view with a slide-in and fade effect
+    /// - Parameters:
+    ///   - duration: Animation duration (default: 0.3 seconds)
+    ///   - slideDistance: Distance to slide in from (default: 50 points)
+    ///   - delay: Delay before starting animation (default: 0)
+    ///   - completion: Optional completion handler
+    func animateIn(duration: TimeInterval = 0.3,
+                   slideDistance: CGFloat = 50,
+                   delay: TimeInterval = 0,
+                   completion: (() -> Void)? = nil) {
+        
+        // Prepare the view for animation
+        self.isHidden = false
+        self.alpha = 0.0
+        self.transform = CGAffineTransform(translationX: 0, y: slideDistance)
+        
+        // Bring to front if it has a superview
+        if let superview = self.superview {
+            superview.bringSubviewToFront(self)
+        }
+        
+        // Ensure user interaction is enabled
+        self.isUserInteractionEnabled = true
+        
+        // Create custom property animator with the same cubic-bezier curve from SitterHomeViewController
+        let animator = UIViewPropertyAnimator(
+            duration: duration,
+            controlPoint1: CGPoint(x: 0.34, y: 1.56),
+            controlPoint2: CGPoint(x: 0.64, y: 1)
+        ) {
+            // Fade in
+            self.alpha = 1.0
+            // Slide into place
+            self.transform = .identity
+        }
+        
+        // Add completion if provided
+        if let completion = completion {
+            animator.addCompletion { _ in
+                completion()
+            }
+        }
+        
+        // Start animation with delay
+        if delay > 0 {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                animator.startAnimation()
+            }
+        } else {
+            animator.startAnimation()
+        }
+    }
+    
+    /// Animates the empty state view out of view with a fade effect
+    /// - Parameters:
+    ///   - duration: Animation duration (default: 0.2 seconds)
+    ///   - slideDistance: Distance to slide out to (default: 20 points)
+    ///   - completion: Optional completion handler
+    func animateOut(duration: TimeInterval = 0.2,
+                    slideDistance: CGFloat = 20,
+                    completion: (() -> Void)? = nil) {
+        
+        // Create animator for fade out
+        let animator = UIViewPropertyAnimator(duration: duration, curve: .easeInOut) {
+            self.alpha = 0.0
+            self.transform = CGAffineTransform(translationX: 0, y: slideDistance)
+        }
+        
+        animator.addCompletion { _ in
+            // Reset state after animation
+            self.isHidden = true
+            self.alpha = 1.0
+            self.transform = .identity
+            completion?()
+        }
+        
+        animator.startAnimation()
+    }
+    
+    /// Shows the empty state immediately without animation
+    func showImmediately() {
+        self.isHidden = false
+        self.alpha = 1.0
+        self.transform = .identity
+        self.isUserInteractionEnabled = true
+        
+        if let superview = self.superview {
+            superview.bringSubviewToFront(self)
+        }
+    }
+    
+    /// Hides the empty state immediately without animation
+    func hideImmediately() {
+        self.isHidden = true
+        self.alpha = 1.0
+        self.transform = .identity
+    }
+    
+    /// Crossfades between showing and hiding the empty state based on a condition
+    /// - Parameters:
+    ///   - shouldShow: Whether to show the empty state
+    ///   - duration: Animation duration (default: 0.3 seconds)
+    ///   - completion: Optional completion handler
+    func crossFade(shouldShow: Bool,
+                   duration: TimeInterval = 0.3,
+                   completion: (() -> Void)? = nil) {
+        
+        if shouldShow && self.isHidden {
+            animateIn(duration: duration, completion: completion)
+        } else if !shouldShow && !self.isHidden {
+            animateOut(duration: duration, completion: completion)
+        } else {
+            completion?()
+        }
+    }
+}

--- a/nest-note/Managers/RatingManager.swift
+++ b/nest-note/Managers/RatingManager.swift
@@ -1,0 +1,135 @@
+//
+//  RatingManager.swift
+//  nest-note
+//
+//  Created by Colton Swapp on 8/24/25.
+//
+
+import Foundation
+import StoreKit
+
+final class RatingManager {
+    
+    // MARK: - Shared Instance
+    static let shared = RatingManager()
+    
+    // MARK: - Keys
+    private struct Keys {
+        static let entriesCreatedCount = "entriesCreatedCount"
+        static let hasInvitedSitter = "hasInvitedSitter"
+        static let appLaunchCount = "appLaunchCount"
+        static let hasRequestedRating = "hasRequestedRating"
+        static let lastRatingRequestDate = "lastRatingRequestDate"
+    }
+    
+    // MARK: - Properties
+    private let defaults = UserDefaults.standard
+    private let minimumDaysBetweenRequests: Double = 90 // 3 months between rating requests
+    
+    // MARK: - Initialization
+    private init() {
+        trackAppLaunch()
+    }
+    
+    // MARK: - App Launch Tracking
+    func trackAppLaunch() {
+        let currentCount = defaults.integer(forKey: Keys.appLaunchCount)
+        defaults.set(currentCount + 1, forKey: Keys.appLaunchCount)
+        
+        checkAppLaunchMilestone()
+    }
+    
+    // MARK: - Entry Creation Tracking
+    func trackEntryCreation() {
+        let currentCount = defaults.integer(forKey: Keys.entriesCreatedCount)
+        defaults.set(currentCount + 1, forKey: Keys.entriesCreatedCount)
+        
+        checkEntriesMilestone()
+    }
+    
+    // MARK: - Sitter Invitation Tracking
+    func trackSitterInvitation() {
+        defaults.set(true, forKey: Keys.hasInvitedSitter)
+        
+        checkSitterInvitationMilestone()
+    }
+    
+    // MARK: - Manual Rating Request
+    func requestRatingManually() {
+        requestAppStoreRating(force: true)
+    }
+    
+    // MARK: - Milestone Checks
+    private func checkEntriesMilestone() {
+        let entriesCount = defaults.integer(forKey: Keys.entriesCreatedCount)
+        if entriesCount >= 3 {
+            requestAppStoreRating()
+        }
+    }
+    
+    private func checkSitterInvitationMilestone() {
+        let hasInvited = defaults.bool(forKey: Keys.hasInvitedSitter)
+        if hasInvited {
+            requestAppStoreRating()
+        }
+    }
+    
+    private func checkAppLaunchMilestone() {
+        let launchCount = defaults.integer(forKey: Keys.appLaunchCount)
+        if launchCount >= 5 {
+            requestAppStoreRating()
+        }
+    }
+    
+    // MARK: - Rating Request Logic
+    private func requestAppStoreRating(force: Bool = false) {
+        // Check if we should request rating
+        guard shouldRequestRating(force: force) else { return }
+        
+        // Request rating on main thread
+        DispatchQueue.main.async {
+            if #available(iOS 18.0, *) {
+                if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+                    AppStore.requestReview(in: windowScene)
+                    
+                    // Mark that we've requested a rating
+                    self.defaults.set(true, forKey: Keys.hasRequestedRating)
+                    self.defaults.set(Date(), forKey: Keys.lastRatingRequestDate)
+                    
+                    Logger.log(level: .info, category: .general, message: "Requested App Store rating")
+                }
+            } else {
+                if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+                    SKStoreReviewController.requestReview(in: windowScene)
+                    
+                    // Mark that we've requested a rating
+                    self.defaults.set(true, forKey: Keys.hasRequestedRating)
+                    self.defaults.set(Date(), forKey: Keys.lastRatingRequestDate)
+                    
+                    Logger.log(level: .info, category: .general, message: "Requested App Store rating")
+                }
+            }
+        }
+    }
+    
+    private func shouldRequestRating(force: Bool = false) -> Bool {
+        // Always allow manual requests
+        if force { return true }
+        
+        // Don't request if we've never requested before and haven't hit any milestones
+        let hasRequestedBefore = defaults.bool(forKey: Keys.hasRequestedRating)
+        
+        // If we've requested before, check the time interval
+        if hasRequestedBefore {
+            if let lastRequestDate = defaults.object(forKey: Keys.lastRatingRequestDate) as? Date {
+                let daysSinceLastRequest = Date().timeIntervalSince(lastRequestDate) / 86400 // seconds in a day
+                if daysSinceLastRequest < minimumDaysBetweenRequests {
+                    return false
+                }
+            }
+        }
+        
+        return true
+    }
+    
+}

--- a/nest-note/Scenes/Home/HomeViewControllerType.swift
+++ b/nest-note/Scenes/Home/HomeViewControllerType.swift
@@ -12,7 +12,7 @@ protocol HomeViewControllerType: NNViewController {
     var dataSource: UICollectionViewDiffableDataSource<HomeSection, HomeItem>! { get }
     
     // MARK: - Data Management
-    func refreshData()
+    func refreshData(forceRefresh: Bool)
     func handleError(_ error: Error)
     
     // MARK: - Collection View Setup

--- a/nest-note/Scenes/Home/HomeViewControllerType.swift
+++ b/nest-note/Scenes/Home/HomeViewControllerType.swift
@@ -1,5 +1,10 @@
 import UIKit
 
+// MARK: - Shared Notification Names
+extension Notification.Name {
+    static let appReturnedFromLongBackground = Notification.Name("AppReturnedFromLongBackground")
+}
+
 /// Protocol defining shared functionality between owner and sitter home view controllers
 protocol HomeViewControllerType: NNViewController {
     // MARK: - Properties

--- a/nest-note/Scenes/Home/OwnerHomeViewController.swift
+++ b/nest-note/Scenes/Home/OwnerHomeViewController.swift
@@ -174,8 +174,19 @@ final class OwnerHomeViewController: NNViewController, HomeViewControllerType, N
                 formatter.timeStyle = .none
                 let duration = formatter.string(from: session.startDate, to: session.endDate)
                 
-                // Get sitter name or email
-                let sitterInfo: String? = session.assignedSitter?.name ?? session.assignedSitter?.email
+                // Get sitter name or email, but only if they're not empty strings
+                let sitterName = session.assignedSitter?.name.trimmingCharacters(in: .whitespacesAndNewlines)
+                let sitterEmail = session.assignedSitter?.email.trimmingCharacters(in: .whitespacesAndNewlines)
+                
+                let sitterInfo: String? = {
+                    if let name = sitterName, !name.isEmpty {
+                        return name
+                    } else if let email = sitterEmail, !email.isEmpty {
+                        return email
+                    } else {
+                        return nil
+                    }
+                }()
                 
                 let durationText: String = sitterInfo == nil ? duration : "\(sitterInfo!) • \(duration)"
                 

--- a/nest-note/Scenes/Home/SitterHomeViewController.swift
+++ b/nest-note/Scenes/Home/SitterHomeViewController.swift
@@ -444,8 +444,8 @@ final class SitterHomeViewController: NNViewController, HomeViewControllerType, 
             collectionView.isHidden = true
             emptyStateView.isHidden = false
             
-            // Bring the empty state view to the front
-            view.bringSubviewToFront(emptyStateView)
+            // Animate the empty state into view
+            emptyStateView.animateIn()
             
             // Ensure it's interactive
             emptyStateView.isUserInteractionEnabled = true
@@ -458,7 +458,7 @@ final class SitterHomeViewController: NNViewController, HomeViewControllerType, 
         case .error(let error):
             loadingSpinner.stopAnimating()
             collectionView.isHidden = true
-            emptyStateView.isHidden = false
+            emptyStateView.animateIn()
             handleError(error)
         }
     }
@@ -655,6 +655,13 @@ final class SitterHomeViewController: NNViewController, HomeViewControllerType, 
         
         // Fallback to folder icon if category not found
         return "folder.fill"
+    }
+    
+    // MARK: - Animation Methods
+    
+    
+    private func hideEmptyState() {
+        emptyStateView.hideImmediately()
     }
     
     // MARK: - Helper Methods

--- a/nest-note/Scenes/Home/SitterHomeViewController.swift
+++ b/nest-note/Scenes/Home/SitterHomeViewController.swift
@@ -410,7 +410,7 @@ final class SitterHomeViewController: NNViewController, HomeViewControllerType, 
             .receive(on: DispatchQueue.main)
             .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.refreshData()
+                self?.refreshData(forceRefresh: true)
             }
             .store(in: &cancellables)
         
@@ -418,7 +418,7 @@ final class SitterHomeViewController: NNViewController, HomeViewControllerType, 
             .receive(on: DispatchQueue.main)
             .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.refreshData()
+                self?.refreshData(forceRefresh: true)
             }
             .store(in: &cancellables)
         
@@ -614,7 +614,7 @@ final class SitterHomeViewController: NNViewController, HomeViewControllerType, 
         dataSource.apply(snapshot, animatingDifferences: true)
     }
     
-    func refreshData() {
+    func refreshData(forceRefresh: Bool = false) {
         Task {
             do {
                 try await sitterViewService.fetchCurrentSession()

--- a/nest-note/Scenes/Nest/EntryDetailViewController.swift
+++ b/nest-note/Scenes/Nest/EntryDetailViewController.swift
@@ -59,6 +59,17 @@ final class EntryDetailViewController: NNSheetViewController, NNTippable {
     let entry: BaseEntry?
     private let category: String
     
+    // Track original values for change detection
+    private var originalTitle: String?
+    private var originalContent: String?
+    
+    // Track changes
+    private var hasUnsavedChanges: Bool = false {
+        didSet {
+            updateSaveButtonState()
+        }
+    }
+    
     // MARK: - Initialization
     init(category: String, entry: BaseEntry? = nil, sourceFrame: CGRect? = nil, isReadOnly: Bool = false) {
         self.category = category
@@ -92,6 +103,13 @@ final class EntryDetailViewController: NNSheetViewController, NNTippable {
         contentTextView.text = entry?.content
         contentTextView.delegate = self
         
+        // Store original values for change detection
+        originalTitle = entry?.title
+        originalContent = entry?.content
+        
+        // Add target for title field changes
+        titleField.addTarget(self, action: #selector(titleFieldChanged), for: .editingChanged)
+        
         // Configure folder label with last 2 components
         configureFolderLabel()
         
@@ -108,6 +126,9 @@ final class EntryDetailViewController: NNSheetViewController, NNTippable {
         } else if entry == nil && !isReadOnly {
             contentTextView.becomeFirstResponder()
         }
+        
+        // Initial save button state update
+        updateSaveButtonState()
     }
     
     // MARK: - Setup Methods
@@ -367,6 +388,45 @@ final class EntryDetailViewController: NNSheetViewController, NNTippable {
         }
     }
     
+    // MARK: - Change Detection
+    
+    @objc private func titleFieldChanged() {
+        checkForUnsavedChanges()
+    }
+    
+    private func checkForUnsavedChanges() {
+        let currentTitle = titleField.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let currentContent = contentTextView.text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        let titleChanged = currentTitle != originalTitle
+        let contentChanged = currentContent != originalContent
+        
+        hasUnsavedChanges = titleChanged || contentChanged
+    }
+    
+    private func updateSaveButtonState() {
+        if isReadOnly {
+            saveButton.isHidden = true
+            return
+        }
+        
+        // For new entries, enable save button when title and content are not empty
+        if entry == nil {
+            let titleString = titleField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let contentString = contentTextView.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let hasRequiredContent = !titleString.isEmpty && !contentString.isEmpty
+            saveButton.isEnabled = hasRequiredContent
+            return
+        }
+        
+        // For existing entries, enable save button only when there are changes
+        let titleString = titleField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let contentString = contentTextView.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let hasRequiredContent = !titleString.isEmpty && !contentString.isEmpty
+        
+        saveButton.isEnabled = hasRequiredContent && hasUnsavedChanges
+    }
+    
     // MARK: - Error Handling
     
     private func showErrorAlert(message: String) {
@@ -396,6 +456,10 @@ extension EntryDetailViewController: UITextFieldDelegate {
 extension EntryDetailViewController: UITextViewDelegate {
     func textViewDidBeginEditing(_ textView: UITextView) {
         //
+    }
+    
+    func textViewDidChange(_ textView: UITextView) {
+        checkForUnsavedChanges()
     }
     
     func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {

--- a/nest-note/Scenes/Nest/EntryDetailViewController.swift
+++ b/nest-note/Scenes/Nest/EntryDetailViewController.swift
@@ -326,6 +326,9 @@ final class EntryDetailViewController: NNSheetViewController, NNTippable {
                     // Create entry (limit check is done before showing this VC)
                     try await NestService.shared.createEntry(newEntry)
                     savedEntry = newEntry
+                    
+                    // Track entry creation for rating prompt
+                    RatingManager.shared.trackEntryCreation()
                 }
                 
                 HapticsHelper.lightHaptic()

--- a/nest-note/Scenes/Nest/NestCategoryViewController.swift
+++ b/nest-note/Scenes/Nest/NestCategoryViewController.swift
@@ -423,12 +423,13 @@ class NestCategoryViewController: NNViewController, NestLoadable, CollectionView
     
     func refreshEmptyState() {
         // Show or hide empty state view based on entries, folders, places, and routines count
-        if entries.isEmpty && folders.isEmpty && places.isEmpty && routines.isEmpty {
-            emptyStateView.isHidden = false
-            view.bringSubviewToFront(emptyStateView)
+        let shouldShowEmptyState = entries.isEmpty && folders.isEmpty && places.isEmpty && routines.isEmpty
+        
+        if shouldShowEmptyState {
+            emptyStateView.animateIn()
             addEntryButton?.isHidden = true
         } else {
-            emptyStateView.isHidden = true
+            emptyStateView.animateOut()
             addEntryButton?.isHidden = false
         }
     }

--- a/nest-note/Scenes/Places/PlaceListViewController.swift
+++ b/nest-note/Scenes/Places/PlaceListViewController.swift
@@ -119,7 +119,7 @@ final class PlaceListViewController: NNViewController, NNTippable {
             if self.isLoading {
                 self.loadingIndicator.startAnimating()
                 self.collectionView.isHidden = true
-                self.emptyStateView?.isHidden = true
+                self.emptyStateView?.hideImmediately()
             } else {
                 self.loadingIndicator.stopAnimating()
                 self.updateEmptyState()
@@ -345,14 +345,20 @@ final class PlaceListViewController: NNViewController, NNTippable {
     
     private func updateEmptyState() {
         if isLoading {
-            emptyStateView?.isHidden = true
+            emptyStateView?.hideImmediately()
             collectionView.isHidden = true
             newPlaceButton?.isHidden = true
             return
         }
         
         let isEmpty = places.isEmpty
-        emptyStateView?.isHidden = !isEmpty
+        
+        if isEmpty {
+            emptyStateView?.animateIn()
+        } else {
+            emptyStateView?.animateOut()
+        }
+        
         collectionView.isHidden = isEmpty
         
         // Show new place button only when there are places and we're not in selection mode

--- a/nest-note/Scenes/Sessions/SessionEventViewController.swift
+++ b/nest-note/Scenes/Sessions/SessionEventViewController.swift
@@ -643,6 +643,29 @@ final class SessionEventViewController: NNSheetViewController {
         let nav = UINavigationController(rootViewController: view)
         present(nav, animated: true)
     }
+    
+    @objc private func titleFieldChanged() {
+        checkForUnsavedChanges()
+    }
+    
+    private func checkForUnsavedChanges() {
+        let currentTitle = titleField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let currentStartDate = startControl.date
+        let currentEndDate = endControl.date
+        let currentPlaceId = locationView.place?.id
+        let currentColorIndex = selectedColorIndex
+        
+        hasUnsavedChanges = currentTitle != (originalTitle ?? "") ||
+                           currentStartDate != (originalStartDate ?? Date()) ||
+                           currentEndDate != (originalEndDate ?? Date()) ||
+                           currentPlaceId != originalPlaceId ||
+                           currentColorIndex != originalColorIndex
+    }
+    
+    private func updateSaveButtonState() {
+        saveButton.isEnabled = hasUnsavedChanges || event == nil
+        saveButton.alpha = saveButton.isEnabled ? 1.0 : 0.6
+    }
 }
 
 // MARK: - NNDateTimePickerSheetDelegate

--- a/nest-note/Scenes/Sessions/SessionsViewController.swift
+++ b/nest-note/Scenes/Sessions/SessionsViewController.swift
@@ -418,7 +418,7 @@ class NestSessionsViewController: NNViewController {
         filterView.isEnabled = false
         Task {
             do {
-                emptyStateView.isHidden = true
+                emptyStateView.hideImmediately()
                 loadingSpinner.startAnimating()
                 ctaButton.isEnabled = false
                 guard let nestID = NestService.shared.currentNest?.id else {
@@ -494,11 +494,13 @@ class NestSessionsViewController: NNViewController {
     
     private func updateEmptyState() {
         let hasItems = !filteredSessions.isEmpty
-        emptyStateView.isHidden = hasItems
         
         if !hasItems {
             let (title, subtitle, icon) = emptyStateConfig(for: currentBucket)
             emptyStateView.configure(icon: icon, title: title, subtitle: subtitle)
+            emptyStateView.animateIn()
+        } else {
+            emptyStateView.animateOut()
         }
     }
     

--- a/nest-note/Scenes/Sessions/SitterSessionsViewController.swift
+++ b/nest-note/Scenes/Sessions/SitterSessionsViewController.swift
@@ -315,7 +315,7 @@ class SitterSessionsViewController: NNViewController {
         Task {
             do {
                 filterView.isEnabled = false
-                emptyStateView.isHidden = true
+                emptyStateView.hideImmediately()
                 loadingSpinner.startAnimating()
                 guard let userID = UserService.shared.currentUser?.id else { return }
                 
@@ -397,11 +397,13 @@ class SitterSessionsViewController: NNViewController {
     
     private func updateEmptyState() {
         let hasItems = !filteredSessions.isEmpty
-        emptyStateView.isHidden = hasItems
         
         if !hasItems {
             let (title, subtitle, icon) = emptyStateConfig(for: currentBucket)
             emptyStateView.configure(icon: icon, title: title, subtitle: subtitle)
+            emptyStateView.animateIn()
+        } else {
+            emptyStateView.animateOut()
         }
     }
     

--- a/nest-note/Scenes/Sessions/ViewControllers/SessionCalendarViewController.swift
+++ b/nest-note/Scenes/Sessions/ViewControllers/SessionCalendarViewController.swift
@@ -474,11 +474,13 @@ final class SessionCalendarViewController: NNViewController, CollectionViewLoada
         // Only update empty state for non-sitters
         if !isSitter {
             let hasEvents = !eventsByDate.isEmpty
-            emptyStateView.isHidden = hasEvents
             
             if !hasEvents {
                 let (title, subtitle, icon) = emptyStateConfig(for: dateRange)
                 emptyStateView.configure(icon: icon, title: title, subtitle: subtitle)
+                emptyStateView.animateIn()
+            } else {
+                emptyStateView.animateOut()
             }
         }
     }

--- a/nest-note/Scenes/Settings/SettingsViewController.swift
+++ b/nest-note/Scenes/Settings/SettingsViewController.swift
@@ -354,6 +354,7 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
         let generalItems = [
             ("Notifications", "bell"),
             ("App Icon", "app"),
+            ("Rate App", "star"),
             ("Terms & Privacy", "doc.text"),
             ("Support", "questionmark.circle"),
             ("Reset Setup", "arrow.counterclockwise")
@@ -625,6 +626,8 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
                 let vc = AppIconViewController()
                 let nav = UINavigationController(rootViewController: vc)
                 present(nav, animated: true)
+            case "Rate App":
+                RatingManager.shared.requestRatingManually()
             case "Reset Setup":
                 showResetSetupConfirmation()
             case "Terms & Privacy":
@@ -789,6 +792,7 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
         
         present(alert, animated: true)
     }
+    
     
     deinit {
         NotificationCenter.default.removeObserver(self)

--- a/nest-note/Scenes/Settings/SubscriptionStatusViewController.swift
+++ b/nest-note/Scenes/Settings/SubscriptionStatusViewController.swift
@@ -1,0 +1,249 @@
+import UIKit
+import RevenueCat
+
+final class SubscriptionStatusViewController: NNViewController {
+    
+    // MARK: - Properties
+    private let topImageView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        NNAssetHelper.configureImageView(view, for: .rectanglePatternSmall, with: NNColors.primary)
+        view.alpha = 0.4
+        return view
+    }()
+    
+    private let scrollView: UIScrollView = {
+        let scroll = UIScrollView()
+        scroll.translatesAutoresizingMaskIntoConstraints = false
+        return scroll
+    }()
+    
+    private let containerView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "You're Subscribed!"
+        label.font = .h1
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Thank you for subscribing to NestNote Pro. Your support helps us continue improving the app."
+        label.font = .bodyM
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let subscriptionInfoStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = 16
+        stack.alignment = .fill
+        stack.distribution = .fill
+        return stack
+    }()
+    
+    private let productLabel: UILabel = {
+        let label = UILabel()
+        label.font = .h4
+        label.textColor = .label
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let expirationLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bodyM
+        label.textColor = .secondaryLabel
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private lazy var doneButton: NNPrimaryLabeledButton = {
+        let button = NNPrimaryLabeledButton(title: "Done")
+        button.addTarget(self, action: #selector(doneTapped), for: .touchUpInside)
+        return button
+    }()
+    
+    // MARK: - Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupView()
+        loadSubscriptionInfo()
+    }
+    
+    // MARK: - Setup
+    private func setupView() {
+        view.backgroundColor = .systemBackground
+        
+        // Setup scroll view
+        view.addSubview(topImageView)
+        view.addSubview(scrollView)
+        scrollView.addSubview(containerView)
+        
+        containerView.addSubview(titleLabel)
+        containerView.addSubview(subtitleLabel)
+        containerView.addSubview(subscriptionInfoStackView)
+        
+        // Add subscription info to stack view
+        subscriptionInfoStackView.addArrangedSubview(createInfoCard())
+        
+        // Pin the Done button to the bottom
+        doneButton.pinToBottom(of: view, addBlurEffect: true)
+        topImageView.pinToTop(of: view)
+        
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: topImageView.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: doneButton.topAnchor),
+            
+            containerView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            containerView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            containerView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            containerView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            containerView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+            
+            titleLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 20),
+            titleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 20),
+            titleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -20),
+            
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
+            subtitleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 20),
+            subtitleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -20),
+            
+            subscriptionInfoStackView.topAnchor.constraint(equalTo: subtitleLabel.bottomAnchor, constant: 24),
+            subscriptionInfoStackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 20),
+            subscriptionInfoStackView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -20),
+            subscriptionInfoStackView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -20)
+        ])
+    }
+    
+    private func createInfoCard() -> UIView {
+        let cardView = UIView()
+        cardView.translatesAutoresizingMaskIntoConstraints = false
+        cardView.backgroundColor = NNColors.NNSystemBackground6
+        cardView.layer.cornerRadius = 12
+        cardView.layer.cornerCurve = .continuous
+        
+        let appIconImageView = UIImageView()
+        appIconImageView.translatesAutoresizingMaskIntoConstraints = false
+        appIconImageView.image = UIImage(named: "icon_pattern-preview")
+        appIconImageView.contentMode = .scaleAspectFit
+        appIconImageView.layer.cornerRadius = 6
+        appIconImageView.layer.cornerCurve = .continuous
+        appIconImageView.clipsToBounds = true
+        
+        let checkmarkImageView = UIImageView()
+        checkmarkImageView.translatesAutoresizingMaskIntoConstraints = false
+        checkmarkImageView.image = UIImage(systemName: "checkmark.circle.fill")?
+            .withTintColor(NNColors.primary, renderingMode: .alwaysOriginal)
+        checkmarkImageView.contentMode = .scaleAspectFit
+        
+        let labelStackView = UIStackView()
+        labelStackView.translatesAutoresizingMaskIntoConstraints = false
+        labelStackView.axis = .vertical
+        labelStackView.spacing = 4
+        labelStackView.alignment = .leading
+        
+        labelStackView.addArrangedSubview(productLabel)
+        labelStackView.addArrangedSubview(expirationLabel)
+        
+        cardView.addSubview(appIconImageView)
+        cardView.addSubview(labelStackView)
+        cardView.addSubview(checkmarkImageView)
+        
+        NSLayoutConstraint.activate([
+            cardView.heightAnchor.constraint(greaterThanOrEqualToConstant: 80),
+            
+            appIconImageView.leadingAnchor.constraint(equalTo: cardView.leadingAnchor, constant: 16),
+            appIconImageView.centerYAnchor.constraint(equalTo: cardView.centerYAnchor),
+            appIconImageView.widthAnchor.constraint(equalToConstant: 40),
+            appIconImageView.heightAnchor.constraint(equalToConstant: 40),
+            
+            labelStackView.leadingAnchor.constraint(equalTo: appIconImageView.trailingAnchor, constant: 12),
+            labelStackView.trailingAnchor.constraint(equalTo: checkmarkImageView.leadingAnchor, constant: -12),
+            labelStackView.centerYAnchor.constraint(equalTo: cardView.centerYAnchor),
+            
+            checkmarkImageView.trailingAnchor.constraint(equalTo: cardView.trailingAnchor, constant: -16),
+            checkmarkImageView.centerYAnchor.constraint(equalTo: cardView.centerYAnchor),
+            checkmarkImageView.widthAnchor.constraint(equalToConstant: 24),
+            checkmarkImageView.heightAnchor.constraint(equalToConstant: 24)
+        ])
+        
+        return cardView
+    }
+    
+    private func loadSubscriptionInfo() {
+        Task {
+            let customerInfo = await SubscriptionService.shared.getCustomerInfo()
+            await MainActor.run {
+                updateSubscriptionInfo(with: customerInfo)
+            }
+        }
+    }
+    
+    private func updateSubscriptionInfo(with customerInfo: CustomerInfo?) {
+        guard let customerInfo = customerInfo else {
+            productLabel.text = "NestNote Pro"
+            expirationLabel.text = "Status: Active"
+            return
+        }
+        
+        // Get active subscription info
+        if let activeSubscription = customerInfo.activeSubscriptions.first {
+            let productId = activeSubscription
+            
+            // Format product name
+            let productName = formatProductName(productId)
+            productLabel.text = productName
+            
+            // Get expiration date
+            if let expirationDate = customerInfo.expirationDate(forProductIdentifier: productId) {
+                let formatter = DateFormatter()
+                formatter.dateStyle = .medium
+                formatter.timeStyle = .none
+                
+                if expirationDate.timeIntervalSinceNow > 0 {
+                    expirationLabel.text = "Expires: \(formatter.string(from: expirationDate))"
+                } else {
+                    expirationLabel.text = "Status: Expired"
+                }
+            } else {
+                expirationLabel.text = "Status: Active"
+            }
+        } else {
+            productLabel.text = "NestNote Pro"
+            expirationLabel.text = "Status: Active"
+        }
+    }
+    
+    private func formatProductName(_ productId: String) -> String {
+        // Convert product ID to user-friendly name
+        if productId.contains("monthly") {
+            return "NestNote Pro (Monthly)"
+        } else if productId.contains("annual") || productId.contains("yearly") {
+            return "NestNote Pro (Annual)"
+        } else {
+            return "NestNote Pro"
+        }
+    }
+    
+    // MARK: - Actions
+    @objc private func doneTapped() {
+        dismiss(animated: true)
+    }
+}

--- a/nest-note/Scenes/Sitters/ViewControllers/InviteDetailViewController.swift
+++ b/nest-note/Scenes/Sitters/ViewControllers/InviteDetailViewController.swift
@@ -309,6 +309,9 @@ class InviteDetailViewController: NNViewController {
                     self.applySnapshot()
                     self.delegate?.inviteSitterViewControllerDidSendInvite(to: selectedSitter, inviteId: invite.id)
                     
+                    // Track sitter invitation for rating prompt
+                    RatingManager.shared.trackSitterInvitation()
+                    
                     // Call the closure to notify that invite creation is complete
                     self.onInviteCreation?()
                     

--- a/nest-note/Scenes/Sitters/ViewControllers/SitterListViewController.swift
+++ b/nest-note/Scenes/Sitters/ViewControllers/SitterListViewController.swift
@@ -353,15 +353,16 @@ class SitterListViewController: NNViewController, CollectionViewLoadable {
             )
         }
         
-        // Update visibility based on data state
-        UIView.animate(withDuration: 0.3) {
-            self.emptyStateView.alpha = shouldShowEmptyState ? 1.0 : 0.0
-            self.collectionView.alpha = shouldShowEmptyState ? 0.0 : 1.0
+        // Update visibility based on data state with crossfade
+        emptyStateView.crossFade(shouldShow: shouldShowEmptyState, duration: 0.3) { [weak self] in
+            guard let self = self else { return }
+            self.collectionView.isHidden = shouldShowEmptyState
         }
         
-        // Update hidden state after animation
-        emptyStateView.isHidden = !shouldShowEmptyState
-        collectionView.isHidden = shouldShowEmptyState
+        // Animate collection view alpha
+        UIView.animate(withDuration: 0.3) {
+            self.collectionView.alpha = shouldShowEmptyState ? 0.0 : 1.0
+        }
     }
     
     private func setupBottomButtonStack() {

--- a/nest-note/Services/Tracker.swift
+++ b/nest-note/Services/Tracker.swift
@@ -59,6 +59,9 @@ class Tracker {
         case regularSignUpSucceeded = "regularSignUpSucceeded"
         case userLoggedOut = "userLoggedOut"
         
+        // MARK: - App Lifecycle Events
+        case appBackgroundReturn = "app_background_return"
+        
         // MARK: - Misc
         case pinnedCategoriesUpdated = "pinnedCategoriesUpdated"
     }
@@ -101,5 +104,28 @@ class Tracker {
         }
         
         Analytics.logEvent(eventName, parameters: parameters)
+    }
+    
+    // MARK: - App Background Return Event
+    func trackAppBackgroundReturn(backgroundDurationMinutes: Int, requiresRefresh: Bool) {
+        var parameters: [String: Any] = [
+            "background_duration_minutes": backgroundDurationMinutes,
+            "requires_refresh": requiresRefresh
+        ]
+        
+        // Add user context
+        if let userEmail = cachedUserEmail {
+            parameters["user_email"] = userEmail
+        }
+        
+        if let userID = cachedUserID {
+            parameters["user_id"] = userID
+        }
+        
+        if let nestId = NestService.shared.currentNest?.id {
+            parameters["nest_id"] = nestId
+        }
+        
+        Analytics.logEvent(NNEventName.appBackgroundReturn.rawValue, parameters: parameters)
     }
 }

--- a/nest-note/SupportingFiles/AppDelegate.swift
+++ b/nest-note/SupportingFiles/AppDelegate.swift
@@ -34,6 +34,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         // Initialize feature flags
         _ = FeatureFlagService.shared
         
+        // Initialize rating manager to track app launches
+        _ = RatingManager.shared
+        
         return true
     }
     


### PR DESCRIPTION
- Wrote logic for coming to the app from a backgrounded state and ensuring things reload if beyond certain threshold + pull to refresh on `HomeViewControllers`
- Added code to ask for App Rating
- Added a screen to show if the user is already subscribed to `Pro` and taps on the `subscription` button
- Made a cleaner Nest Setup flow for a sitter who transitions into owner mode without having a nest setup
- Added delayed `Event` creation for if a session isn't created yet and the user is trying to setup a session with events
- Added code to disable the `Update` button on 2 different screens until changes were detected