### PR TITLE
Release/1.2.5

### DIFF
--- a/nest-note.xcodeproj/project.pbxproj
+++ b/nest-note.xcodeproj/project.pbxproj
@@ -256,7 +256,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = "nest-note/nest-note.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = X89M6X46Y8;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -271,7 +271,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Swappfunc.nest-note";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -293,7 +293,7 @@
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
 				CODE_SIGN_ENTITLEMENTS = "nest-note/nest-note.entitlements";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = X89M6X46Y8;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -308,7 +308,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.1;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Swappfunc.nest-note";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/nest-note.xcodeproj/project.pbxproj
+++ b/nest-note.xcodeproj/project.pbxproj
@@ -271,7 +271,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Swappfunc.nest-note";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -308,7 +308,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.2.3;
+				MARKETING_VERSION = 1.2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Swappfunc.nest-note";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/nest-note.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/nest-note.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "699177330d2896ea8775ea00d0c08a86396b4a2d9ed9b01907df8a52b60abcce",
+  "originHash" : "96e8106f002ef0f689a1861534ab3d7e68b431862fa10ed2aa4fad1fa75b372e",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/RevenueCat/purchases-ios-spm",
       "state" : {
-        "revision" : "cdfe7100fc8cca4a655a9c0f1d34e1fcbc40edd0",
-        "version" : "5.28.1"
+        "revision" : "6238361173aa15a02b99de0d6c003b24fa5fa444",
+        "version" : "5.52.1"
       }
     },
     {

--- a/nest-note/Common/Logger.swift
+++ b/nest-note/Common/Logger.swift
@@ -124,6 +124,7 @@ public extension Logger {
         case testing = "🧪 Testing"
         case survey = "📝 Survey"
         case referral = "🎟️ Referral"
+        case paywall = "🤑 Paywall"
     }
 
 }

--- a/nest-note/Common/Logger.swift
+++ b/nest-note/Common/Logger.swift
@@ -127,6 +127,7 @@ public extension Logger {
         case testing = "🧪 Testing"
         case survey = "📝 Survey"
         case referral = "🎟️ Referral"
+        case paywall = "🤑 Paywall"
     }
 
 }

--- a/nest-note/Common/Views/NNEmptyStateView.swift
+++ b/nest-note/Common/Views/NNEmptyStateView.swift
@@ -1,8 +1,9 @@
 import UIKit
 
-protocol NNEmptyStateViewDelegate: AnyObject {
+@objc protocol NNEmptyStateViewDelegate: AnyObject {
     func emptyStateViewDidTapActionButton(_ emptyStateView: NNEmptyStateView)
     func emptyStateView(_ emptyStateView: NNEmptyStateView, didTapActionWithTag tag: Int)
+    @objc optional func emptyStateViewDidTapSecondaryActionButton(_ emptyStateView: NNEmptyStateView)
 }
 
 class NNEmptyStateView: UIView {
@@ -56,7 +57,7 @@ class NNEmptyStateView: UIView {
     }()
     
     private(set) var actionButtons: [NNSmallPrimaryButton] = []
-    
+
     private lazy var actionButton: NNSmallPrimaryButton = {
         let button = NNSmallPrimaryButton(title: "Test", backgroundColor: NNColors.primary.withAlphaComponent(0.15), foregroundColor: NNColors.primary)
         button.addTarget(self, action: #selector(actionButtonTapped), for: .touchUpInside)
@@ -64,6 +65,8 @@ class NNEmptyStateView: UIView {
         button.tag = 0
         return button
     }()
+
+    private var secondaryActionButton: UIButton?
     
     init(icon: UIImage?, title: String, subtitle: String, actionButtonTitle: String? = nil, actionButtonMenu: UIMenu? = nil) {
         super.init(frame: .zero)
@@ -89,7 +92,7 @@ class NNEmptyStateView: UIView {
         stackView.addArrangedSubview(subtitleLabel)
         stackView.addArrangedSubview(buttonStackView)
         buttonStackView.addArrangedSubview(actionButton)
-        
+
         stackView.setCustomSpacing(16, after: subtitleLabel)
         
         // Ensure the view itself is user interaction enabled
@@ -117,7 +120,7 @@ class NNEmptyStateView: UIView {
         )
         titleLabel.text = title
         subtitleLabel.text = subtitle
-        
+
         if let buttonTitle = actionButtonTitle {
             actionButton.setTitle(buttonTitle, for: .normal)
             actionButton.isHidden = false
@@ -126,7 +129,7 @@ class NNEmptyStateView: UIView {
         }
 
         if let icon {
-            iconImageView.isHidden = false  
+            iconImageView.isHidden = false
         } else {
             iconImageView.isHidden = true
         }
@@ -135,7 +138,38 @@ class NNEmptyStateView: UIView {
     @objc private func actionButtonTapped() {
         delegate?.emptyStateViewDidTapActionButton(self)
     }
-    
+
+    @objc private func secondaryActionButtonTapped() {
+        delegate?.emptyStateViewDidTapSecondaryActionButton?(self)
+    }
+
+    /// Adds a secondary action button below the primary action button
+    /// - Parameter title: The title for the secondary button
+    func addSecondaryAction(title: String) {
+        // Only create if it doesn't exist
+        guard secondaryActionButton == nil else {
+            // If it exists, just update the title
+            var config = secondaryActionButton?.configuration
+            config?.title = title
+            secondaryActionButton?.configuration = config
+            secondaryActionButton?.isHidden = false
+            return
+        }
+
+        // Create the secondary action button
+        var config = UIButton.Configuration.plain()
+        config.title = title
+        config.baseForegroundColor = .systemBlue
+        let button = UIButton(configuration: config)
+        button.addTarget(self, action: #selector(secondaryActionButtonTapped), for: .touchUpInside)
+
+        // Add to stack view
+        stackView.addArrangedSubview(button)
+        stackView.setCustomSpacing(8, after: buttonStackView)
+
+        secondaryActionButton = button
+    }
+
     func addMenuToActionButton(menu: UIMenu) {
         actionButton.showsMenuAsPrimaryAction = true
         actionButton.menu = menu

--- a/nest-note/Common/Views/NNSegmentedFilterView.swift
+++ b/nest-note/Common/Views/NNSegmentedFilterView.swift
@@ -1,0 +1,63 @@
+import UIKit
+
+protocol NNSegmentedFilterViewDelegate: AnyObject {
+    func segmentedFilterView(_ filterView: NNSegmentedFilterView, didSelectSegmentAtIndex index: Int)
+}
+
+final class NNSegmentedFilterView: UIView {
+    // MARK: - Properties
+    weak var delegate: NNSegmentedFilterViewDelegate?
+    
+    private let segmentedControl: UISegmentedControl = {
+        let control = UISegmentedControl()
+        control.translatesAutoresizingMaskIntoConstraints = false
+        return control
+    }()
+    
+    // MARK: - Initialization
+    init(items: [String]) {
+        super.init(frame: .zero)
+        segmentedControl.removeAllSegments()
+        for (index, item) in items.enumerated() {
+            segmentedControl.insertSegment(withTitle: item, at: index, animated: false)
+        }
+        setup()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Setup
+    private func setup() {
+        addSubview(segmentedControl)
+        
+        segmentedControl.addTarget(self, action: #selector(segmentedControlValueChanged), for: .valueChanged)
+        
+        NSLayoutConstraint.activate([
+            segmentedControl.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            segmentedControl.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            segmentedControl.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            segmentedControl.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+            segmentedControl.heightAnchor.constraint(equalToConstant: 32).with(priority: .defaultLow)
+        ])
+        
+        // Height is set via frame, not constraint (matching NNCompactCalendarView pattern)
+    }
+    
+    // MARK: - Public Methods
+    var selectedSegmentIndex: Int {
+        get { segmentedControl.selectedSegmentIndex }
+        set { segmentedControl.selectedSegmentIndex = newValue }
+    }
+    
+    var isEnabled: Bool {
+        get { segmentedControl.isEnabled }
+        set { segmentedControl.isEnabled = newValue }
+    }
+    
+    // MARK: - Actions
+    @objc private func segmentedControlValueChanged() {
+        delegate?.segmentedFilterView(self, didSelectSegmentAtIndex: segmentedControl.selectedSegmentIndex)
+    }
+}

--- a/nest-note/Common/Views/NestCreationCardView.swift
+++ b/nest-note/Common/Views/NestCreationCardView.swift
@@ -219,6 +219,17 @@ class NestCreationCardView: UIView {
         setNeedsLayout()
         layoutIfNeeded()
     }
+    
+    func configureForNewSitter() {
+        nestNameLabel.text = "World's Best Sitter"
+        newNestBadgeLabel.text = "New sitter".uppercased()
+        
+        creationDateLabel.text = "New sitter on the block"
+
+        // Force layout update
+        setNeedsLayout()
+        layoutIfNeeded()
+    }
 
     override func layoutSubviews() {
         super.layoutSubviews()

--- a/nest-note/Common/Views/NestCreationCardView.swift
+++ b/nest-note/Common/Views/NestCreationCardView.swift
@@ -1,0 +1,248 @@
+import UIKit
+
+class NestCreationCardView: UIView {
+
+    // Add content view to manage hierarchy
+    private let contentView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .secondarySystemGroupedBackground
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.clipsToBounds = true
+        view.layer.cornerRadius = 12
+        return view
+    }()
+
+    // Top pattern image (uses NNAssetType.rectanglePattern)
+    private let topPatternView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.clipsToBounds = true
+        return imageView
+    }()
+
+    // Perforation dashed separator
+    private let perforationView: UIView = {
+        let view = UIView()
+        view.isUserInteractionEnabled = false
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let perforationLayer: CAShapeLayer = {
+        let layer = CAShapeLayer()
+        layer.lineWidth = 2
+        layer.lineDashPattern = [6, 6]
+        layer.fillColor = UIColor.clear.cgColor
+        layer.strokeColor = UIColor.systemGray5.cgColor
+        return layer
+    }()
+
+    private let nestNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .h2
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        label.text = "Anderson Nest"
+        return label
+    }()
+
+    // Badge styled like NNCategoryFilterView's enabled chip
+    private let newNestBadgeView: UIView = {
+        let view = UIView()
+        view.layer.borderWidth = 2
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let newNestBadgeLabel: UILabel = {
+        let label = UILabel()
+        label.font = .h4
+        label.text = "NEW NEST"
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let creationDateLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bodyL
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.textColor = .secondaryLabel
+        return label
+    }()
+
+    // App icon with shadow: use a container for shadow, inner image for rounded mask
+    private let appIconContainer: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        // Shadow on container (not clipped)
+        view.layer.shadowColor = UIColor.black.cgColor
+        view.layer.shadowOpacity = 0.2
+        view.layer.shadowOffset = CGSize(width: 0, height: 4)
+        view.layer.shadowRadius = 8
+        view.layer.masksToBounds = false
+        return view
+    }()
+
+    private let appIconView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(named: "icon_pattern-preview")
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.clipsToBounds = true
+        imageView.layer.cornerRadius = 16
+        return imageView
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    func updatePattern(size: CGFloat, spacing: CGFloat, alpha: CGFloat) {
+        // Update alpha for the pattern view
+        topPatternView.alpha = alpha
+    }
+
+    private func setupView() {
+        backgroundColor = .clear
+        layer.cornerRadius = 12
+        layer.masksToBounds = false
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.3
+        layer.shadowOffset = CGSize(width: 4, height: 8)
+        layer.shadowRadius = 8
+
+        // Configure top pattern image using NNAssetType.rectanglePattern
+        if let image = UIImage(named: NNAssetType.rectanglePattern.rawValue) {
+            topPatternView.image = image
+            topPatternView.contentMode = .scaleAspectFill
+            topPatternView.alpha = NNAssetType.rectanglePattern.defaultAlpha
+        }
+
+        // Add content view (clipping container)
+        addSubview(contentView)
+
+        // Background pattern and perforation inside contentView so they clip
+        contentView.addSubview(topPatternView)
+        contentView.addSubview(perforationView)
+        perforationView.layer.addSublayer(perforationLayer)
+
+        // Badge setup
+        newNestBadgeView.addSubview(newNestBadgeLabel)
+        newNestBadgeView.backgroundColor = NNColors.primaryOpaque
+        newNestBadgeView.layer.borderColor = NNColors.primary.cgColor
+        newNestBadgeLabel.textColor = NNColors.primary
+
+        // Add content elements
+        [newNestBadgeView, appIconContainer, nestNameLabel, creationDateLabel].forEach { view in
+            view.isUserInteractionEnabled = false
+            contentView.addSubview(view)
+        }
+        // Place the icon image inside the shadow container
+        appIconContainer.addSubview(appIconView)
+
+        setupConstraints()
+    }
+
+    private func setupConstraints() {
+        NSLayoutConstraint.activate([
+            // Content view constraints
+            contentView.topAnchor.constraint(equalTo: topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            // Top pattern view (only top section)
+            topPatternView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: -12),
+            topPatternView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            topPatternView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            topPatternView.heightAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.4),
+
+            // Perforation directly under the pattern
+            perforationView.topAnchor.constraint(equalTo: topPatternView.bottomAnchor),
+            perforationView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 0),
+            perforationView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: 0),
+            perforationView.heightAnchor.constraint(equalToConstant: 1),
+
+            // Badge over the perforation (centered)
+            newNestBadgeView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            newNestBadgeView.centerYAnchor.constraint(equalTo: perforationView.centerYAnchor),
+
+            // Badge label padding
+            newNestBadgeLabel.topAnchor.constraint(equalTo: newNestBadgeView.topAnchor, constant: 6),
+            newNestBadgeLabel.leadingAnchor.constraint(equalTo: newNestBadgeView.leadingAnchor, constant: 14),
+            newNestBadgeLabel.trailingAnchor.constraint(equalTo: newNestBadgeView.trailingAnchor, constant: -14),
+            newNestBadgeLabel.bottomAnchor.constraint(equalTo: newNestBadgeView.bottomAnchor, constant: -6),
+
+            // App icon container below perforation
+            appIconContainer.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            appIconContainer.topAnchor.constraint(equalTo: perforationView.bottomAnchor, constant: 48),
+            appIconContainer.widthAnchor.constraint(equalToConstant: 100),
+            appIconContainer.heightAnchor.constraint(equalTo: appIconContainer.widthAnchor),
+
+            // Icon fills its container
+            appIconView.topAnchor.constraint(equalTo: appIconContainer.topAnchor),
+            appIconView.leadingAnchor.constraint(equalTo: appIconContainer.leadingAnchor),
+            appIconView.trailingAnchor.constraint(equalTo: appIconContainer.trailingAnchor),
+            appIconView.bottomAnchor.constraint(equalTo: appIconContainer.bottomAnchor),
+
+            // Title and dates centered under icon
+            nestNameLabel.topAnchor.constraint(equalTo: appIconContainer.bottomAnchor, constant: 24),
+            nestNameLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            nestNameLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+
+            creationDateLabel.topAnchor.constraint(equalTo: nestNameLabel.bottomAnchor, constant: 8),
+            creationDateLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            creationDateLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20)
+        ])
+    }
+
+    func configure(nestName: String, createdDate: Date) {
+        nestNameLabel.text = nestName
+
+        // Configure creation date with clean format
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .long
+        dateFormatter.timeStyle = .none
+
+        creationDateLabel.text = dateFormatter.string(from: createdDate)
+
+        // Force layout update
+        setNeedsLayout()
+        layoutIfNeeded()
+    }
+    
+    func configureForNewSitter() {
+        nestNameLabel.text = "World's Best Sitter"
+        newNestBadgeLabel.text = "New sitter".uppercased()
+        
+        creationDateLabel.text = "New sitter on the block"
+
+        // Force layout update
+        setNeedsLayout()
+        layoutIfNeeded()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // Update dashed line path
+        perforationLayer.frame = perforationView.bounds
+        let path = UIBezierPath()
+        let midY: CGFloat = perforationView.bounds.height / 2
+        path.move(to: CGPoint(x: 0, y: midY))
+        path.addLine(to: CGPoint(x: perforationView.bounds.width, y: midY))
+        perforationLayer.path = path.cgPath
+        // Update colors on trait changes dynamically
+        perforationLayer.strokeColor = UIColor.systemGray3.withAlphaComponent(0.3).cgColor
+
+        newNestBadgeView.layer.cornerRadius = newNestBadgeView.frame.size.height / 2
+    }
+}

--- a/nest-note/Models/SessionItem.swift
+++ b/nest-note/Models/SessionItem.swift
@@ -193,6 +193,9 @@ class SessionItem: Hashable, Codable, SessionDisplayable {
     
     /// Determines if the session can be marked as active based on business rules
     var canBeMarkedActive: Bool {
+        // Can't mark pending sessions as active
+        guard status != .pendingOwnerSetup else { return false }
+
         // Can be marked active if it's upcoming and within 24 hours of start time
         if status == .upcoming {
             return startDate.timeIntervalSinceNow <= 24 * 60 * 60 // 24 hours
@@ -208,11 +211,16 @@ class SessionItem: Hashable, Codable, SessionDisplayable {
     
     /// Infers the status based on dates and current status
     func inferredStatus(at currentDate: Date = Date()) -> SessionStatus {
+        // Don't auto-transition from pendingOwnerSetup
+        if status == .pendingOwnerSetup {
+            return .pendingOwnerSetup
+        }
+
         // Don't override manually set completed status
         if status == .completed {
             return .completed
         }
-        
+
         // Handle early access status
         if status == .earlyAccess {
             // Check if early access has expired
@@ -221,7 +229,7 @@ class SessionItem: Hashable, Codable, SessionDisplayable {
             }
             return .earlyAccess
         }
-        
+
         // Don't override manually set active status unless the session is over
         if status == .inProgress {
             if currentDate > endDate {
@@ -229,7 +237,7 @@ class SessionItem: Hashable, Codable, SessionDisplayable {
             }
             return .inProgress
         }
-        
+
         // Automatic status inference
         if currentDate < startDate {
             return .upcoming
@@ -337,6 +345,7 @@ protocol Containable {
 }
 
 enum SessionStatus: String, Codable, Containable {
+    case pendingOwnerSetup = "pendingOwnerSetup"
     case upcoming
     case inProgress = "inProgress"
     case extended
@@ -369,6 +378,8 @@ enum SessionStatus: String, Codable, Containable {
     
     var icon: String {
         switch self {
+        case .pendingOwnerSetup:
+            return "clock.badge.questionmark"
         case .upcoming:
             return "calendar.badge.clock"
         case .inProgress:
@@ -386,6 +397,8 @@ enum SessionStatus: String, Codable, Containable {
     
     var displayName: String {
         switch self {
+        case .pendingOwnerSetup:
+            return "Pending Setup"
         case .inProgress:
             return "In Progress"
         case .earlyAccess:

--- a/nest-note/Models/SessionItem.swift
+++ b/nest-note/Models/SessionItem.swift
@@ -190,6 +190,9 @@ class SessionItem: Hashable, Codable, SessionDisplayable {
     
     /// Determines if the session can be marked as active based on business rules
     var canBeMarkedActive: Bool {
+        // Can't mark pending sessions as active
+        guard status != .pendingOwnerSetup else { return false }
+
         // Can be marked active if it's upcoming and within 24 hours of start time
         if status == .upcoming {
             return startDate.timeIntervalSinceNow <= 24 * 60 * 60 // 24 hours
@@ -205,11 +208,16 @@ class SessionItem: Hashable, Codable, SessionDisplayable {
     
     /// Infers the status based on dates and current status
     func inferredStatus(at currentDate: Date = Date()) -> SessionStatus {
+        // Don't auto-transition from pendingOwnerSetup
+        if status == .pendingOwnerSetup {
+            return .pendingOwnerSetup
+        }
+
         // Don't override manually set completed status
         if status == .completed {
             return .completed
         }
-        
+
         // Handle early access status
         if status == .earlyAccess {
             // Check if early access has expired
@@ -218,7 +226,7 @@ class SessionItem: Hashable, Codable, SessionDisplayable {
             }
             return .earlyAccess
         }
-        
+
         // Don't override manually set active status unless the session is over
         if status == .inProgress {
             if currentDate > endDate {
@@ -226,7 +234,7 @@ class SessionItem: Hashable, Codable, SessionDisplayable {
             }
             return .inProgress
         }
-        
+
         // Automatic status inference
         if currentDate < startDate {
             return .upcoming
@@ -331,6 +339,7 @@ protocol Containable {
 }
 
 enum SessionStatus: String, Codable, Containable {
+    case pendingOwnerSetup = "pendingOwnerSetup"
     case upcoming
     case inProgress = "inProgress"
     case extended
@@ -363,6 +372,8 @@ enum SessionStatus: String, Codable, Containable {
     
     var icon: String {
         switch self {
+        case .pendingOwnerSetup:
+            return "clock.badge.questionmark"
         case .upcoming:
             return "calendar.badge.clock"
         case .inProgress:
@@ -380,6 +391,8 @@ enum SessionStatus: String, Codable, Containable {
     
     var displayName: String {
         switch self {
+        case .pendingOwnerSetup:
+            return "Pending Setup"
         case .inProgress:
             return "In Progress"
         case .earlyAccess:

--- a/nest-note/Resources/sitter_survey_config.json
+++ b/nest-note/Resources/sitter_survey_config.json
@@ -2,25 +2,6 @@
     "version": "1.0",
     "questions": [
         {
-            "id": "missing_information",
-            "title": "What information do you most often find missing or unclear when babysitting?",
-            "subtitle": "Missing information can be frustrating!",
-            "options": [
-                "Emergency contacts",
-                "Household systems (alarm, garage, appliances)",
-                "Children's routines or schedules",
-                "Food/dietary restrictions",
-                "Medical information",
-                "House rules",
-                "Where to find essential items",
-                "Neighborhood information",
-                "DEBUG - Test scenario"
-            ],
-            "multi_select": true,
-            "category": "information",
-            "order": 1
-        },
-        {
             "id": "important_information",
             "title": "Which information would be most helpful to have organized in a single place?",
             "subtitle": "Select all that apply.",
@@ -36,7 +17,7 @@
             ],
             "multi_select": true,
             "category": "information",
-            "order": 2
+            "order": 1
         },
         {
             "id": "helpful_features",
@@ -55,7 +36,7 @@
             ],
             "multi_select": true,
             "category": "features",
-            "order": 3
+            "order": 2
         }
     ]
 } 

--- a/nest-note/Scenes/Common/Extensions/Date+Extensions.swift
+++ b/nest-note/Scenes/Common/Extensions/Date+Extensions.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 extension Date {
     /// Initialize a Date with specific components
@@ -104,12 +105,230 @@ extension Date {
         return calendar.date(from: components) ?? self
     }
     
+    /// Synchronizes the end date to use the same day as the start date while preserving the end time
+    /// Used when toggling from multi-day to single-day session
+    /// - Parameters:
+    ///   - startDate: The start date to use for the day component
+    ///   - endDate: The end date to extract the time component from
+    /// - Returns: A new date with startDate's day and endDate's time, or nil if unable to create
+    static func syncEndDateToStartDay(startDate: Date, endDate: Date) -> Date? {
+        let calendar = Calendar.current
+        let startComponents = calendar.dateComponents([.year, .month, .day], from: startDate)
+        let endTimeComponents = calendar.dateComponents([.hour, .minute], from: endDate)
+
+        var newComponents = DateComponents()
+        newComponents.year = startComponents.year
+        newComponents.month = startComponents.month
+        newComponents.day = startComponents.day
+        newComponents.hour = endTimeComponents.hour
+        newComponents.minute = endTimeComponents.minute
+
+        return calendar.date(from: newComponents)
+    }
+
     /// Example usage:
     /// ```
     /// let now = Date() // 2:45 PM
     /// let nextHour = now.roundedToNextHour() // 3:00 PM
     /// let next15Min = now.roundedToNext15Minutes() // 3:00 PM
+    ///
+    /// // Sync dates for single-day session
+    /// let start = Date.from(year: 2024, month: 1, day: 15, hour: 9, minute: 0)! // Jan 15, 9:00 AM
+    /// let end = Date.from(year: 2024, month: 1, day: 17, hour: 17, minute: 0)!   // Jan 17, 5:00 PM
+    /// let synced = Date.syncEndDateToStartDay(startDate: start, endDate: end)    // Jan 15, 5:00 PM
     /// ```
+}
+
+// MARK: - Date Synchronization Utility
+
+/// Result of date synchronization operation
+struct DateSynchronizationResult {
+    let adjustedStartDate: Date
+    let adjustedEndDate: Date
+}
+
+/// Result of date validation operation
+enum DateValidationResult {
+    case valid
+    case invalidStartAfterEnd
+    case invalidSameTime
+    
+    var errorTitle: String {
+        switch self {
+        case .valid:
+            return ""
+        case .invalidStartAfterEnd, .invalidSameTime:
+            return "Invalid Time Range"
+        }
+    }
+    
+    var errorMessage: String {
+        switch self {
+        case .valid:
+            return ""
+        case .invalidStartAfterEnd:
+            return "The start time cannot be after the end time."
+        case .invalidSameTime:
+            return "The start and end times cannot be the same."
+        }
+    }
+}
+
+/// Utility for validating session date ranges
+struct SessionDateValidator {
+    /// Validates a date range for sessions
+    /// - Parameters:
+    ///   - startDate: The start date/time
+    ///   - endDate: The end date/time
+    ///   - isMultiDay: Whether this is a multi-day session (affects overnight validation)
+    /// - Returns: Validation result indicating if dates are valid or what error occurred
+    static func validateDateRange(startDate: Date, endDate: Date, isMultiDay: Bool = false) -> DateValidationResult {
+        let calendar = Calendar.current
+        
+        // For single-day sessions, check if this is an overnight session (end time wraps to next day)
+        if !isMultiDay {
+            let startTime = calendar.dateComponents([.hour, .minute], from: startDate)
+            let endTime = calendar.dateComponents([.hour, .minute], from: endDate)
+            
+            // If end time is before start time, it's likely an overnight session
+            // Compare just the time components to detect overnight sessions
+            if let startHour = startTime.hour, let startMin = startTime.minute,
+               let endHour = endTime.hour, let endMin = endTime.minute {
+                let startMinutes = startHour * 60 + startMin
+                let endMinutes = endHour * 60 + endMin
+                
+                // If end time is before start time, it's an overnight session (valid)
+                if endMinutes < startMinutes {
+                    // This is a valid overnight session - end time is on the next day
+                    return .valid
+                }
+            }
+        }
+        
+        // Check if start date is after end date (for multi-day or same-day sessions)
+        if calendar.compare(startDate, to: endDate, toGranularity: .minute) == .orderedDescending {
+            return .invalidStartAfterEnd
+        }
+        
+        // Check if start and end times are the same
+        if calendar.compare(startDate, to: endDate, toGranularity: .minute) == .orderedSame {
+            return .invalidSameTime
+        }
+        
+        return .valid
+    }
+    
+    /// Validates a date range and shows an alert if invalid
+    /// - Parameters:
+    ///   - startDate: The start date/time
+    ///   - endDate: The end date/time
+    ///   - isMultiDay: Whether this is a multi-day session (affects overnight validation)
+    ///   - viewController: The view controller to present the alert from
+    /// - Returns: true if valid, false if invalid (alert is shown automatically)
+    static func validateAndShowAlertIfNeeded(startDate: Date, endDate: Date, isMultiDay: Bool = false, in viewController: UIViewController) -> Bool {
+        let result = validateDateRange(startDate: startDate, endDate: endDate, isMultiDay: isMultiDay)
+        
+        guard result == .valid else {
+            let alert = UIAlertController(
+                title: result.errorTitle,
+                message: result.errorMessage,
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: "OK", style: .default))
+            viewController.present(alert, animated: true)
+            return false
+        }
+        
+        return true
+    }
+}
+
+/// Utility for synchronizing session dates when start date/time changes
+struct SessionDateSynchronizer {
+    /// Synchronizes dates based on picker type and session configuration
+    /// - Parameters:
+    ///   - pickerType: The type of date picker that was changed
+    ///   - newDate: The new date selected from the picker
+    ///   - previousStartDate: The previous start date (before change)
+    ///   - currentEndDate: The current end date
+    ///   - isMultiDay: Whether this is a multi-day session
+    /// - Returns: Adjusted start and end dates
+    static func synchronizeDates(
+        pickerType: NNDateTimePickerSheet.PickerType,
+        newDate: Date,
+        previousStartDate: Date,
+        currentEndDate: Date,
+        isMultiDay: Bool
+    ) -> DateSynchronizationResult {
+        let calendar = Calendar.current
+        // Initialize with previous values - only change what's being edited
+        var adjustedStartDate = previousStartDate
+        var adjustedEndDate = currentEndDate
+        
+        switch pickerType {
+        case .startDate:
+            adjustedStartDate = newDate
+            
+            if isMultiDay {
+                // For multi-day stays, if start date is now after end date, adjust end date
+                if adjustedStartDate >= adjustedEndDate {
+                    // Calculate the original duration between start and end dates
+                    let duration = calendar.dateComponents([.day, .hour, .minute], from: previousStartDate, to: currentEndDate)
+                    
+                    // If there was a positive duration, preserve it relative to the new start date
+                    if let days = duration.day, days > 0 {
+                        if let adjustedEnd = calendar.date(byAdding: .day, value: days, to: adjustedStartDate) {
+                            adjustedEndDate = adjustedEnd
+                        } else {
+                            // Fallback: set end date to start date + 1 day
+                            adjustedEndDate = calendar.date(byAdding: .day, value: 1, to: adjustedStartDate) ?? adjustedEndDate
+                        }
+                    } else {
+                        // Default: set end date to start date + 1 day
+                        adjustedEndDate = calendar.date(byAdding: .day, value: 1, to: adjustedStartDate) ?? adjustedEndDate
+                    }
+                }
+            } else {
+                // If single-day session, sync end date to the new start date's day
+                if let syncedEndDate = Date.syncEndDateToStartDay(startDate: adjustedStartDate, endDate: adjustedEndDate) {
+                    // Ensure end time is after start time - if not, adjust end time to be 1 hour after start
+                    if syncedEndDate <= adjustedStartDate {
+                        adjustedEndDate = calendar.date(byAdding: .hour, value: 1, to: adjustedStartDate) ?? syncedEndDate
+                    } else {
+                        adjustedEndDate = syncedEndDate
+                    }
+                }
+            }
+            
+        case .startTime:
+            adjustedStartDate = newDate
+            
+            // If single-day session, sync end date to the new start date's day
+            if !isMultiDay {
+                if let syncedEndDate = Date.syncEndDateToStartDay(startDate: adjustedStartDate, endDate: adjustedEndDate) {
+                    // Ensure end time is after start time - if not, adjust end time to be 1 hour after start
+                    if syncedEndDate <= adjustedStartDate {
+                        adjustedEndDate = calendar.date(byAdding: .hour, value: 1, to: adjustedStartDate) ?? syncedEndDate
+                    } else {
+                        adjustedEndDate = syncedEndDate
+                    }
+                }
+            }
+            
+        case .endDate, .endTime:
+            adjustedEndDate = newDate
+            
+            // If end time is now before or equal to start time, adjust start time to be 1 hour before end time
+            if adjustedEndDate <= adjustedStartDate {
+                adjustedStartDate = calendar.date(byAdding: .hour, value: -1, to: adjustedEndDate) ?? adjustedStartDate
+            }
+        }
+        
+        return DateSynchronizationResult(
+            adjustedStartDate: adjustedStartDate,
+            adjustedEndDate: adjustedEndDate
+        )
+    }
 }
 
 extension Calendar {

--- a/nest-note/Scenes/Home/HomeCollectionView/NestCell.swift
+++ b/nest-note/Scenes/Home/HomeCollectionView/NestCell.swift
@@ -11,6 +11,7 @@ class NestCell: UICollectionViewCell {
     let titleLabel = UILabel()
     let subtitleLabel = UILabel()
     let imageView = UIImageView()
+    private let textStackView = UIStackView()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -24,43 +25,46 @@ class NestCell: UICollectionViewCell {
     
     private func setupViews() {
         // Configure title label
-        titleLabel.font = .h2
+        titleLabel.font = .h3
         
         // Configure subtitle label
         subtitleLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
         subtitleLabel.textColor = .secondaryLabel
-        subtitleLabel.numberOfLines = 2
+        subtitleLabel.numberOfLines = 1
         subtitleLabel.lineBreakMode = .byTruncatingTail
         
         // Configure image view
         imageView.contentMode = .scaleAspectFit
         
+        // Configure stack view
+        textStackView.axis = .vertical
+        textStackView.spacing = 2
+        textStackView.alignment = .leading
+        textStackView.distribution = .fill
+        
+        // Add labels to stack view
+        textStackView.addArrangedSubview(titleLabel)
+        textStackView.addArrangedSubview(subtitleLabel)
+        
         // Add subviews
-        contentView.addSubview(titleLabel)
-        contentView.addSubview(subtitleLabel)
+        contentView.addSubview(textStackView)
         contentView.addSubview(imageView)
         
         // Disable autoresizing masks
-        titleLabel.translatesAutoresizingMaskIntoConstraints = false
-        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        textStackView.translatesAutoresizingMaskIntoConstraints = false
         imageView.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
-            // Image view constraints - top right corner
-            imageView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 20),
-            imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
-            imageView.widthAnchor.constraint(equalToConstant: 100),
-            imageView.heightAnchor.constraint(equalToConstant: 100),
+            // Image view constraints - center right
+            imageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            imageView.widthAnchor.constraint(equalToConstant: 72),
+            imageView.heightAnchor.constraint(equalToConstant: 72),
             
-            // Title label constraints - bottom left
-            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
-            titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: imageView.leadingAnchor, constant: -20),
-            titleLabel.bottomAnchor.constraint(equalTo: subtitleLabel.topAnchor, constant: -4),
-            
-            // Subtitle label constraints - below title, bottom left
-            subtitleLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
-            subtitleLabel.trailingAnchor.constraint(lessThanOrEqualTo: imageView.leadingAnchor, constant: -20),
-            subtitleLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -20)
+            // Stack view constraints - center left, vertically centered
+            textStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            textStackView.trailingAnchor.constraint(lessThanOrEqualTo: imageView.leadingAnchor, constant: -12),
+            textStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
         ])
     }
     

--- a/nest-note/Scenes/Home/HomeViewControllerType.swift
+++ b/nest-note/Scenes/Home/HomeViewControllerType.swift
@@ -158,10 +158,10 @@ extension HomeViewControllerType {
                 return section
                 
             case .nest:
-                // Full width item with fixed height of 220
-                let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(200))
+                // Compact nest cell with reduced height
+                let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(80))
                 let item = NSCollectionLayoutItem(layoutSize: itemSize)
-                let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(200))
+                let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(80))
                 let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
                 let section = NSCollectionLayoutSection(group: group)
                 section.contentInsets = NSDirectionalEdgeInsets(top: verticalSpacing + 4, leading: 18, bottom: 20, trailing: 18)

--- a/nest-note/Scenes/Home/SitterHomeViewController.swift
+++ b/nest-note/Scenes/Home/SitterHomeViewController.swift
@@ -43,7 +43,7 @@ final class SitterHomeViewController: NNViewController, HomeViewControllerType, 
         view.isHidden = true
         view.isUserInteractionEnabled = true
         view.delegate = self
-        
+
         return view
     }()
     
@@ -63,7 +63,6 @@ final class SitterHomeViewController: NNViewController, HomeViewControllerType, 
         super.setup()
         configureCollectionView()
         navigationItem.title = "NestNote"
-        navigationItem.weeTitle = "Welcome to"
         navigationController?.navigationBar.prefersLargeTitles = true
         navigationController?.navigationBar.tintColor = NNColors.primary
         
@@ -136,10 +135,10 @@ final class SitterHomeViewController: NNViewController, HomeViewControllerType, 
                 return section
                 
             case .nest:
-                // Full width item with fixed height of 220
-                let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(200))
+                // Compact nest cell with reduced height
+                let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(80))
                 let item = NSCollectionLayoutItem(layoutSize: itemSize)
-                let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(200))
+                let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(80))
                 let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
                 let section = NSCollectionLayoutSection(group: group)
                 section.contentInsets = NSDirectionalEdgeInsets(top: verticalSpacing + 4, leading: 18, bottom: 20, trailing: 18)
@@ -865,10 +864,11 @@ extension SitterHomeViewController: UICollectionViewDelegate {
 
 extension SitterHomeViewController: NNEmptyStateViewDelegate {
     func emptyStateView(_ emptyStateView: NNEmptyStateView, didTapActionWithTag tag: Int) {
-        //
+        // Legacy support for tag-based actions (not used anymore)
     }
-    
+
     func emptyStateViewDidTapActionButton(_ emptyStateView: NNEmptyStateView) {
+        // Primary action - Join a Session
         let joinVC = JoinSessionViewController()
         joinVC.delegate = self
         let nav = UINavigationController(rootViewController: joinVC)
@@ -927,8 +927,10 @@ extension SitterHomeViewController: SessionCalendarViewControllerDelegate {
     func calendarViewController(_ controller: SessionCalendarViewController, didUpdateEvents events: [SessionEvent]) {
         // Update local events array
         sessionEvents = events
-        
+
         // Update events section
         updateEventsSection(with: events)
     }
 } 
+
+

--- a/nest-note/Scenes/Home/SitterHomeViewController.swift
+++ b/nest-note/Scenes/Home/SitterHomeViewController.swift
@@ -43,7 +43,7 @@ final class SitterHomeViewController: NNViewController, HomeViewControllerType, 
         view.isHidden = true
         view.isUserInteractionEnabled = true
         view.delegate = self
-        
+
         return view
     }()
     
@@ -59,7 +59,6 @@ final class SitterHomeViewController: NNViewController, HomeViewControllerType, 
         super.setup()
         configureCollectionView()
         navigationItem.title = "NestNote"
-        navigationItem.weeTitle = "Welcome to"
         navigationController?.navigationBar.prefersLargeTitles = true
         navigationController?.navigationBar.tintColor = NNColors.primary
         
@@ -132,10 +131,10 @@ final class SitterHomeViewController: NNViewController, HomeViewControllerType, 
                 return section
                 
             case .nest:
-                // Full width item with fixed height of 220
-                let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(200))
+                // Compact nest cell with reduced height
+                let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(80))
                 let item = NSCollectionLayoutItem(layoutSize: itemSize)
-                let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(200))
+                let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(80))
                 let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
                 let section = NSCollectionLayoutSection(group: group)
                 section.contentInsets = NSDirectionalEdgeInsets(top: verticalSpacing + 4, leading: 18, bottom: 20, trailing: 18)
@@ -877,10 +876,11 @@ extension SitterHomeViewController: UICollectionViewDelegate {
 
 extension SitterHomeViewController: NNEmptyStateViewDelegate {
     func emptyStateView(_ emptyStateView: NNEmptyStateView, didTapActionWithTag tag: Int) {
-        //
+        // Legacy support for tag-based actions (not used anymore)
     }
-    
+
     func emptyStateViewDidTapActionButton(_ emptyStateView: NNEmptyStateView) {
+        // Primary action - Join a Session
         let joinVC = JoinSessionViewController()
         joinVC.delegate = self
         let nav = UINavigationController(rootViewController: joinVC)
@@ -939,9 +939,10 @@ extension SitterHomeViewController: SessionCalendarViewControllerDelegate {
     func calendarViewController(_ controller: SessionCalendarViewController, didUpdateEvents events: [SessionEvent]) {
         // Update local events array
         sessionEvents = events
-        
+
         // Update events section
         updateEventsSection(with: events)
     }
 }
+
 

--- a/nest-note/Scenes/Home/Views/HomeNestCell.swift
+++ b/nest-note/Scenes/Home/Views/HomeNestCell.swift
@@ -34,9 +34,9 @@ enum HomeNestType {
     var defaultIcon: String {
         switch self {
         case .sitterAccess:
-            return "house.lodge.fill"
+            return "house.lodge"
         case .ownerPrimary:
-            return "house.lodge.fill"
+            return "house.lodge"
         case .ownerSecondary:
             return "house.lodge"
         }

--- a/nest-note/Scenes/Home/Views/HomeSessionCell.swift
+++ b/nest-note/Scenes/Home/Views/HomeSessionCell.swift
@@ -193,6 +193,9 @@ final class HomeSessionCell: UICollectionViewListCell {
             statusImageView.tintColor = .systemGreen
         case .archived, .earlyAccess:
             break
+        case .pendingOwnerSetup:
+            statusLabel.textColor = .systemYellow
+            statusImageView.tintColor = .systemYellow
         }
         
         // Configure date display

--- a/nest-note/Scenes/LoginViewController.swift
+++ b/nest-note/Scenes/LoginViewController.swift
@@ -39,6 +39,7 @@ final class LoginViewController: NNViewController {
         label.text = "Welcome to NestNote"
         label.font = .h1
         label.textAlignment = .center
+        label.numberOfLines = 0
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()

--- a/nest-note/Scenes/LoginViewController.swift
+++ b/nest-note/Scenes/LoginViewController.swift
@@ -23,6 +23,7 @@ final class LoginViewController: NNViewController {
         label.text = "Welcome to NestNote"
         label.font = .h1
         label.textAlignment = .center
+        label.numberOfLines = 0
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
     }()

--- a/nest-note/Scenes/Nest/SessionDetailViewController.swift
+++ b/nest-note/Scenes/Nest/SessionDetailViewController.swift
@@ -235,26 +235,10 @@ final class SessionDetailViewController: NNSheetViewController {
     @objc func multiDayToggleTapped() {
         endControl.setStyle(multiDayToggle.isOn ? .both : .time, animated: true)
         
-        // If turning off multi-day, sync the end date with start date
+        // If turning off multi-day, sync the end date with start date using centralized utility
         if !multiDayToggle.isOn {
-            let calendar = Calendar.current
-            
-            // Get date components from start date
-            let startComponents = calendar.dateComponents([.year, .month, .day], from: startControl.date)
-            // Get time components from end date (to preserve the end time)
-            let endTimeComponents = calendar.dateComponents([.hour, .minute], from: endControl.date)
-            
-            // Combine the start date with end time
-            var newComponents = DateComponents()
-            newComponents.year = startComponents.year
-            newComponents.month = startComponents.month
-            newComponents.day = startComponents.day
-            newComponents.hour = endTimeComponents.hour
-            newComponents.minute = endTimeComponents.minute
-            
-            // Create new date and update end control
-            if let newDate = calendar.date(from: newComponents) {
-                endControl.date = newDate
+            if let syncedDate = Date.syncEndDateToStartDay(startDate: startControl.date, endDate: endControl.date) {
+                endControl.date = syncedDate
             }
         }
     }
@@ -281,36 +265,7 @@ final class SessionDetailViewController: NNSheetViewController {
     }
     
     private func validateDates() -> Bool {
-        let calendar = Calendar.current
-        let startDate = startControl.date
-        let endDate = endControl.date
-        
-        // Compare dates
-        if calendar.compare(startDate, to: endDate, toGranularity: .minute) == .orderedDescending {
-            // Start date is after end date - show error
-            let alert = UIAlertController(
-                title: "Invalid Time Range",
-                message: "The start time cannot be after the end time.",
-                preferredStyle: .alert
-            )
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
-            present(alert, animated: true)
-            return false
-        }
-        
-        // Optionally, we could also check if they're exactly equal
-        if calendar.compare(startDate, to: endDate, toGranularity: .minute) == .orderedSame {
-            let alert = UIAlertController(
-                title: "Invalid Time Range",
-                message: "The start and end times cannot be the same.",
-                preferredStyle: .alert
-            )
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
-            present(alert, animated: true)
-            return false
-        }
-        
-        return true
+        return SessionDateValidator.validateAndShowAlertIfNeeded(startDate: startControl.date, endDate: endControl.date, isMultiDay: multiDayToggle.isOn, in: self)
     }
     
     @objc private func saveButtonTapped() {

--- a/nest-note/Scenes/Onboarding/NNOnboardingSurveyViewController.swift
+++ b/nest-note/Scenes/Onboarding/NNOnboardingSurveyViewController.swift
@@ -269,6 +269,17 @@ class NNOnboardingSurveyViewController: NNOnboardingViewController {
         guard let question = currentQuestion else { return nil }
         return (question.id, getSelectedOptions())
     }
+
+    func setTestOptions(_ testOptions: [SurveyOption], isMultiSelect: Bool = true) {
+        print("🔍 [Survey VC] Setting test options:")
+        for (index, option) in testOptions.enumerated() {
+            print("  [\(index)] '\(option.title)' - subtitle: '\(option.subtitle ?? "nil")'")
+        }
+        self.options = testOptions
+        self.isMultiSelect = isMultiSelect
+        collectionView?.reloadData()
+        print("🔍 [Survey VC] Reloaded collection view")
+    }
     
     // MARK: - Private Methods
     private func updateScrollingBehavior() {

--- a/nest-note/Scenes/Onboarding/OBFinishViewController.swift
+++ b/nest-note/Scenes/Onboarding/OBFinishViewController.swift
@@ -55,12 +55,22 @@ final class OBFinishViewController: NNOnboardingViewController, MFMailComposeVie
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        setupOnboarding(
-            title: "Finishing up...",
-            subtitle: "Gathering twigs, grass, and leaves for your nest..."
-        )
-        
+
+        // Get user role to customize loading text
+        let userRole = (coordinator as? OnboardingCoordinator)?.currentRole ?? .nestOwner
+
+        if userRole == .sitter {
+            setupOnboarding(
+                title: "Finishing up...",
+                subtitle: "Preparing your perch..."
+            )
+        } else {
+            setupOnboarding(
+                title: "Finishing up...",
+                subtitle: "Gathering twigs, grass, and leaves for your nest..."
+            )
+        }
+
         setupContent()
     }
     
@@ -235,8 +245,133 @@ final class OBFinishViewController: NNOnboardingViewController, MFMailComposeVie
         // Reset failure count on success
         Self.resetFailureCount()
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
-            (self.coordinator as? OnboardingCoordinator)?.completeOnboarding()
+        // Get user role to determine which success screen to show
+        let userRole = (coordinator as? OnboardingCoordinator)?.currentRole ?? .nestOwner
+
+        // Configure the card based on user role
+        if userRole == .sitter {
+            // For sitters, use the sitter-specific configuration
+            nestCreationCardView.configureForNewSitter()
+        } else {
+            // For nest owners, show their nest name
+            let nestName = (coordinator as? OnboardingCoordinator)?.currentNestName ?? "Your Nest"
+            nestCreationCardView.configure(nestName: nestName, createdDate: Date())
+        }
+
+        // Start the beautiful animation sequence
+        animateSuccessSequence()
+    }
+
+    private func animateSuccessSequence() {
+        // Phase 1: Hide loading indicator (0.3s)
+        UIView.animate(withDuration: 0.3) {
+            self.activityIndicator.alpha = 0
+        }
+    }
+
+    private func animateCardEntrance() {
+        // Guard against double execution
+        guard !hasStartedCardAnimation else {
+            return
+        }
+        hasStartedCardAnimation = true
+
+        // First make it visible and add slight rotation
+        nestCreationCardView.alpha = 1
+        nestCreationCardView.transform = CGAffineTransform(rotationAngle: 2 * .pi / 180)
+        glowView.alpha = 1.0
+        glowView2.alpha = 1.0
+        glowView3.alpha = 1.0
+
+        // Remove current constraint and add new one (copied from JoinSessionViewController)
+        cardBottomConstraint?.isActive = false
+        cardBottomConstraint = nestCreationCardView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 0)
+        cardBottomConstraint?.isActive = true
+
+        // Animate it up from the bottom with spring effect (copied from JoinSessionViewController)
+        UIView.animate(withDuration: 0.4, delay: 0, usingSpringWithDamping: 0.8, initialSpringVelocity: 0.5) {
+            self.view.layoutIfNeeded()
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.03) { [weak self] in
+            guard let self else { return }
+            ExplosionManager.trigger(.atomic, at: CGPoint(x: view.center.x, y: view.frame.maxY))
+            HapticsHelper.lightHaptic()
+        }
+    }
+
+    private func animateSlideToEnterEntrance() {
+        // Guard against double execution
+        guard !hasStartedSlideAnimation else {
+            return
+        }
+        hasStartedSlideAnimation = true
+
+        // Get user role to customize the text
+        let userRole = (coordinator as? OnboardingCoordinator)?.currentRole ?? .nestOwner
+
+        if userRole == .sitter {
+            self.titleLabel.text = "Welcome to NestNote!"
+            self.subtitleLabel.text = "Swipe below to start exploring."
+        } else {
+            self.titleLabel.text = "Your nest has been created!"
+            self.subtitleLabel.text = "Swipe below to enter your nest."
+        }
+
+        // Keep it hidden, only use alpha for fade-in control
+        self.slideToEnterView.isHidden = false
+        self.slideToEnterView.alpha = 0.0
+        
+
+        UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 0.8, initialSpringVelocity: 0.2) {
+            self.titleLabel.alpha = 1
+            self.subtitleLabel.alpha = 1
+        }
+
+        // Simple fade in for slide-to-enter (no transform animation)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            // Ensure alpha is 0 right before animation (override any internal slider logic)
+            self.slideToEnterView.alpha = 0.0
+
+            UIView.animate(withDuration: 0.4) {
+                self.slideToEnterView.alpha = 1.0
+            }
+        }
+    }
+
+    private func handleSlideComplete() {
+        // Stop all animations
+        glowView.layer.removeAllAnimations()
+        glowView2.layer.removeAllAnimations()
+        glowView3.layer.removeAllAnimations()
+
+        // Fade out all elements
+        UIView.animate(withDuration: 0.5) {
+            self.nestCreationCardView.alpha = 0
+            self.glowView.alpha = 0
+            self.glowView2.alpha = 0
+            self.glowView3.alpha = 0
+            self.slideToEnterView.alpha = 0
+        }
+
+        // Complete onboarding after animation
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            if self.isDebugMode {
+                // In debug mode, just dismiss
+                self.dismiss(animated: true)
+            } else {
+                // Normal flow - complete onboarding
+                (self.coordinator as? OnboardingCoordinator)?.completeOnboarding()
+            }
+        }
+    }
+
+    // Add method to enable debug mode
+    func enableDebugMode() {
+        isDebugMode = true
+        // Start directly with success animation for testing
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.playSuccessTransition()
         }
     }
 

--- a/nest-note/Scenes/Onboarding/OBFinishViewController.swift
+++ b/nest-note/Scenes/Onboarding/OBFinishViewController.swift
@@ -136,12 +136,22 @@ final class OBFinishViewController: NNOnboardingViewController, MFMailComposeVie
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        setupOnboarding(
-            title: "Finishing up...",
-            subtitle: "Gathering twigs, grass, and leaves for your nest..."
-        )
-        
+
+        // Get user role to customize loading text
+        let userRole = (coordinator as? OnboardingCoordinator)?.currentRole ?? .nestOwner
+
+        if userRole == .sitter {
+            setupOnboarding(
+                title: "Finishing up...",
+                subtitle: "Preparing your perch..."
+            )
+        } else {
+            setupOnboarding(
+                title: "Finishing up...",
+                subtitle: "Gathering twigs, grass, and leaves for your nest..."
+            )
+        }
+
         setupContent()
     }
     
@@ -365,9 +375,18 @@ final class OBFinishViewController: NNOnboardingViewController, MFMailComposeVie
         // Reset failure count on success
         Self.resetFailureCount()
 
-        // Configure the card with nest information
-        let nestName = (coordinator as? OnboardingCoordinator)?.currentNestName ?? "Your Nest"
-        nestCreationCardView.configure(nestName: nestName, createdDate: Date())
+        // Get user role to determine which success screen to show
+        let userRole = (coordinator as? OnboardingCoordinator)?.currentRole ?? .nestOwner
+
+        // Configure the card based on user role
+        if userRole == .sitter {
+            // For sitters, use the sitter-specific configuration
+            nestCreationCardView.configureForNewSitter()
+        } else {
+            // For nest owners, show their nest name
+            let nestName = (coordinator as? OnboardingCoordinator)?.currentNestName ?? "Your Nest"
+            nestCreationCardView.configure(nestName: nestName, createdDate: Date())
+        }
 
         // Start the beautiful animation sequence
         animateSuccessSequence()
@@ -433,8 +452,16 @@ final class OBFinishViewController: NNOnboardingViewController, MFMailComposeVie
         }
         hasStartedSlideAnimation = true
 
-        self.titleLabel.text = "Your nest has been created!"
-        self.subtitleLabel.text = "Swipe below to enter your nest."
+        // Get user role to customize the text
+        let userRole = (coordinator as? OnboardingCoordinator)?.currentRole ?? .nestOwner
+
+        if userRole == .sitter {
+            self.titleLabel.text = "Welcome to NestNote!"
+            self.subtitleLabel.text = "Swipe below to start exploring."
+        } else {
+            self.titleLabel.text = "Your nest has been created!"
+            self.subtitleLabel.text = "Swipe below to enter your nest."
+        }
 
         // Keep it hidden, only use alpha for fade-in control
         self.slideToEnterView.isHidden = false

--- a/nest-note/Scenes/Onboarding/OBPaywallViewController.swift
+++ b/nest-note/Scenes/Onboarding/OBPaywallViewController.swift
@@ -12,68 +12,188 @@ import RevenueCatUI
 final class OBPaywallViewController: NNOnboardingViewController, PaywallViewControllerDelegate {
     
     private var paywallViewController: PaywallViewController?
-    
+    private var hasCompletedPaywall: Bool = false
+    private var hasPurchased: Bool = false
+    private var hasShownExitOffer: Bool = false
+    private var offeringId: String? // Offering to display (nil = default, "partner" = partner offering)
+    private var exitOfferingId: String? // Exit offer to display on dismissal
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
+        // Get offering ID from coordinator (partner offering if they have a referral code)
+        offeringId = (coordinator as? OnboardingCoordinator)?.paywallOfferingId
+
+        // Set exit offer ID to show the winback offering when user dismisses
+        exitOfferingId = "winback"
+
         setupOnboarding(
             title: "Unlock Premium Features",
             subtitle: "Get the most out of NestNote with unlimited entries and premium features."
         )
-        
-        setupPaywall()
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        presentPaywall()
+        if paywallViewController == nil {
+            setupAndPresentPaywall(isExitOffer: false)
+        }
     }
-    
-    private func setupPaywall() {
-        paywallViewController = PaywallViewController()
-        paywallViewController?.delegate = self
+
+    private func setupAndPresentPaywall(isExitOffer: Bool) {
+        Task {
+            do {
+                // Fetch offerings from RevenueCat
+                let offerings = try await Purchases.shared.offerings()
+
+                let offeringIdToUse = isExitOffer ? exitOfferingId : offeringId
+                let offering: Offering?
+
+                if let offeringIdToUse = offeringIdToUse {
+                    offering = offerings.offering(identifier: offeringIdToUse)
+                    if let offering = offering {
+                        if isExitOffer {
+                            Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Showing exit offer (winback)")
+                        } else {
+                            Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Showing \(offeringIdToUse) offering")
+                        }
+                    }
+                } else {
+                    offering = offerings.current
+                    Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Showing default offering")
+                }
+
+                await MainActor.run {
+                    if let offering = offering {
+                        paywallViewController = PaywallViewController(offering: offering)
+                    } else {
+                        paywallViewController = PaywallViewController()
+                    }
+                    paywallViewController?.delegate = self
+                    presentPaywall()
+                }
+
+            } catch {
+                Logger.log(level: .error, category: .paywall, message: "🎯 PAYWALL: Failed to fetch offerings: \(error.localizedDescription)")
+
+                await MainActor.run {
+                    paywallViewController = PaywallViewController()
+                    paywallViewController?.delegate = self
+                    presentPaywall()
+                }
+            }
+        }
     }
-    
+
     private func presentPaywall() {
         guard let paywallViewController = paywallViewController else { return }
-        
-        // Present the paywall modally
         paywallViewController.modalPresentationStyle = .pageSheet
         present(paywallViewController, animated: true)
     }
-    
-    // MARK: - PaywallViewControllerDelegate
-    
-    func paywallViewController(_ controller: PaywallViewController, didFinishPurchasingWith customerInfo: CustomerInfo) {
-        // Purchase successful, dismiss paywall and continue onboarding
-        controller.dismiss(animated: true) { [weak self] in
-            (self?.coordinator as? OnboardingCoordinator)?.next()
+
+    private func completePaywallAndContinue() {
+        guard !hasCompletedPaywall else {
+            // Already completed, ignore duplicate calls
+            return
         }
-    }
-    
-    func paywallViewController(_ controller: PaywallViewController, didFailPurchasingWith error: Error) {
-        // Purchase failed, but allow user to continue
-        controller.dismiss(animated: true) { [weak self] in
-            (self?.coordinator as? OnboardingCoordinator)?.next()
-        }
-    }
-    
-    func paywallViewController(_ controller: PaywallViewController, didFinishRestoringWith customerInfo: CustomerInfo) {
-        // Restore successful, dismiss paywall and continue onboarding
-        controller.dismiss(animated: true) { [weak self] in
-            (self?.coordinator as? OnboardingCoordinator)?.next()
-        }
-    }
-    
-    func paywallViewController(_ controller: PaywallViewController, didFailRestoringWith error: Error) {
-        // Restore failed, but allow user to continue
-        controller.dismiss(animated: true) { [weak self] in
-            (self?.coordinator as? OnboardingCoordinator)?.next()
-        }
-    }
-    
-    func paywallViewControllerWasDismissed(_ controller: PaywallViewController) {
-        // User dismissed the paywall without purchasing, continue onboarding
+        hasCompletedPaywall = true
         (coordinator as? OnboardingCoordinator)?.next()
+    }
+
+    override func reset() {
+        super.reset()
+        hasCompletedPaywall = false
+        hasPurchased = false
+        hasShownExitOffer = false
+    }
+
+    // MARK: - PaywallViewControllerDelegate
+
+    func paywallViewController(_ controller: PaywallViewController, didFinishPurchasingWith customerInfo: CustomerInfo) {
+        hasPurchased = true
+
+        // Track conversion
+        let productId = customerInfo.activeSubscriptions.first ?? "unknown_product"
+        let conversionSource = hasShownExitOffer ? "exit_offer" : "main_paywall"
+        OnboardingAnalyticsService.shared.recordConversion(type: "purchase", productId: productId)
+
+        // Track which offering was used
+        let currentOfferingId = hasShownExitOffer ? exitOfferingId : offeringId
+        if let currentOfferingId = currentOfferingId {
+            Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Conversion completed with \(currentOfferingId) offering (\(conversionSource))")
+            Analytics.logEvent("paywall_conversion", parameters: [
+                "offering_id": currentOfferingId,
+                "product_id": productId,
+                "conversion_source": conversionSource
+            ])
+        } else {
+            Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Conversion completed (\(conversionSource))")
+            Analytics.logEvent("paywall_conversion", parameters: [
+                "product_id": productId,
+                "conversion_source": conversionSource
+            ])
+        }
+
+        Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Purchase complete")
+
+        // Dismiss and continue
+        controller.dismiss(animated: true) { [weak self] in
+            (self?.coordinator as? OnboardingCoordinator)?.next()
+        }
+    }
+
+    func paywallViewController(_ controller: PaywallViewController, didFinishRestoringWith customerInfo: CustomerInfo) {
+        hasPurchased = true
+
+        // Track restoration
+        let productId = customerInfo.activeSubscriptions.first ?? "restored_product"
+        OnboardingAnalyticsService.shared.recordConversion(type: "restore", productId: productId)
+
+        if let offeringId = offeringId {
+            Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Restore completed with \(offeringId) offering")
+            Analytics.logEvent("paywall_restore", parameters: [
+                "offering_id": offeringId,
+                "product_id": productId
+            ])
+        }
+
+        Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Restore complete")
+
+        // Dismiss and continue
+        controller.dismiss(animated: true) { [weak self] in
+            (self?.coordinator as? OnboardingCoordinator)?.next()
+        }
+    }
+
+    func paywallViewController(_ controller: PaywallViewController, didFailPurchasingWith error: Error) {
+        Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Purchase failed: \(error.localizedDescription)")
+    }
+
+    func paywallViewController(_ controller: PaywallViewController, didFailRestoringWith error: Error) {
+        Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Restore failed: \(error.localizedDescription)")
+    }
+
+    func paywallViewControllerWasDismissed(_ controller: PaywallViewController) {
+        Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Paywall dismissed - purchased: \(hasPurchased), shown exit offer: \(hasShownExitOffer)")
+
+        // If user dismissed without purchasing and we haven't shown exit offer yet, show it
+        if !hasPurchased && !hasShownExitOffer {
+            hasShownExitOffer = true
+            Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Showing exit offer")
+
+            // Reset paywall controller for exit offer
+            paywallViewController = nil
+
+            // Show exit offer after a brief delay
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                self?.setupAndPresentPaywall(isExitOffer: true)
+            }
+        } else {
+            // Either they purchased or already saw exit offer - continue
+            if !hasPurchased {
+                Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: User declined after exit offer, continuing onboarding")
+            }
+            completePaywallAndContinue()
+        }
     }
 }

--- a/nest-note/Scenes/Onboarding/OBPaywallViewController.swift
+++ b/nest-note/Scenes/Onboarding/OBPaywallViewController.swift
@@ -14,32 +14,80 @@ final class OBPaywallViewController: NNOnboardingViewController, PaywallViewCont
 
     private var paywallViewController: PaywallViewController?
     private var hasCompletedPaywall: Bool = false
-    
+    private var hasPurchased: Bool = false
+    private var hasShownExitOffer: Bool = false
+    private var offeringId: String? // Offering to display (nil = default, "partner" = partner offering)
+    private var exitOfferingId: String? // Exit offer to display on dismissal
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
+        // Get offering ID from coordinator (partner offering if they have a referral code)
+        offeringId = (coordinator as? OnboardingCoordinator)?.paywallOfferingId
+
+        // Set exit offer ID to show the winback offering when user dismisses
+        exitOfferingId = "winback"
+
         setupOnboarding(
             title: "Unlock Premium Features",
             subtitle: "Get the most out of NestNote with unlimited entries and premium features."
         )
-        
-        setupPaywall()
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        presentPaywall()
+        if paywallViewController == nil {
+            setupAndPresentPaywall(isExitOffer: false)
+        }
     }
-    
-    private func setupPaywall() {
-        paywallViewController = PaywallViewController()
-        paywallViewController?.delegate = self
+
+    private func setupAndPresentPaywall(isExitOffer: Bool) {
+        Task {
+            do {
+                // Fetch offerings from RevenueCat
+                let offerings = try await Purchases.shared.offerings()
+
+                let offeringIdToUse = isExitOffer ? exitOfferingId : offeringId
+                let offering: Offering?
+
+                if let offeringIdToUse = offeringIdToUse {
+                    offering = offerings.offering(identifier: offeringIdToUse)
+                    if let offering = offering {
+                        if isExitOffer {
+                            Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Showing exit offer (winback)")
+                        } else {
+                            Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Showing \(offeringIdToUse) offering")
+                        }
+                    }
+                } else {
+                    offering = offerings.current
+                    Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Showing default offering")
+                }
+
+                await MainActor.run {
+                    if let offering = offering {
+                        paywallViewController = PaywallViewController(offering: offering)
+                    } else {
+                        paywallViewController = PaywallViewController()
+                    }
+                    paywallViewController?.delegate = self
+                    presentPaywall()
+                }
+
+            } catch {
+                Logger.log(level: .error, category: .paywall, message: "🎯 PAYWALL: Failed to fetch offerings: \(error.localizedDescription)")
+
+                await MainActor.run {
+                    paywallViewController = PaywallViewController()
+                    paywallViewController?.delegate = self
+                    presentPaywall()
+                }
+            }
+        }
     }
-    
+
     private func presentPaywall() {
         guard let paywallViewController = paywallViewController else { return }
-
-        // Present the paywall modally
         paywallViewController.modalPresentationStyle = .pageSheet
         present(paywallViewController, animated: true)
     }
@@ -56,48 +104,97 @@ final class OBPaywallViewController: NNOnboardingViewController, PaywallViewCont
     override func reset() {
         super.reset()
         hasCompletedPaywall = false
+        hasPurchased = false
+        hasShownExitOffer = false
     }
-    
+
     // MARK: - PaywallViewControllerDelegate
-    
+
     func paywallViewController(_ controller: PaywallViewController, didFinishPurchasingWith customerInfo: CustomerInfo) {
-        // Track conversion with new analytics system
+        hasPurchased = true
+
+        // Track conversion
         let productId = customerInfo.activeSubscriptions.first ?? "unknown_product"
+        let conversionSource = hasShownExitOffer ? "exit_offer" : "main_paywall"
         OnboardingAnalyticsService.shared.recordConversion(type: "purchase", productId: productId)
 
-        // Purchase successful, dismiss paywall and continue onboarding
+        // Track which offering was used
+        let currentOfferingId = hasShownExitOffer ? exitOfferingId : offeringId
+        if let currentOfferingId = currentOfferingId {
+            Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Conversion completed with \(currentOfferingId) offering (\(conversionSource))")
+            Analytics.logEvent("paywall_conversion", parameters: [
+                "offering_id": currentOfferingId,
+                "product_id": productId,
+                "conversion_source": conversionSource
+            ])
+        } else {
+            Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Conversion completed (\(conversionSource))")
+            Analytics.logEvent("paywall_conversion", parameters: [
+                "product_id": productId,
+                "conversion_source": conversionSource
+            ])
+        }
+
+        Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Purchase complete")
+
+        // Dismiss and continue
         controller.dismiss(animated: true) { [weak self] in
             self?.completePaywallAndContinue()
         }
     }
-    
-    func paywallViewController(_ controller: PaywallViewController, didFailPurchasingWith error: Error) {
-        // Purchase failed, but allow user to continue
-        controller.dismiss(animated: true) { [weak self] in
-            self?.completePaywallAndContinue()
-        }
-    }
-    
+
     func paywallViewController(_ controller: PaywallViewController, didFinishRestoringWith customerInfo: CustomerInfo) {
-        // Track conversion with new analytics system
+        hasPurchased = true
+
+        // Track restoration
         let productId = customerInfo.activeSubscriptions.first ?? "restored_product"
         OnboardingAnalyticsService.shared.recordConversion(type: "restore", productId: productId)
 
-        // Restore successful, dismiss paywall and continue onboarding
+        if let offeringId = offeringId {
+            Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Restore completed with \(offeringId) offering")
+            Analytics.logEvent("paywall_restore", parameters: [
+                "offering_id": offeringId,
+                "product_id": productId
+            ])
+        }
+
+        Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Restore complete")
+
+        // Dismiss and continue
         controller.dismiss(animated: true) { [weak self] in
             self?.completePaywallAndContinue()
         }
     }
-    
+
+    func paywallViewController(_ controller: PaywallViewController, didFailPurchasingWith error: Error) {
+        Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Purchase failed: \(error.localizedDescription)")
+    }
+
     func paywallViewController(_ controller: PaywallViewController, didFailRestoringWith error: Error) {
-        // Restore failed, but allow user to continue
-        controller.dismiss(animated: true) { [weak self] in
-            self?.completePaywallAndContinue()
-        }
+        Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Restore failed: \(error.localizedDescription)")
     }
-    
+
     func paywallViewControllerWasDismissed(_ controller: PaywallViewController) {
-        // User dismissed the paywall without purchasing, continue onboarding
-        completePaywallAndContinue()
+        Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Paywall dismissed - purchased: \(hasPurchased), shown exit offer: \(hasShownExitOffer)")
+
+        // If user dismissed without purchasing and we haven't shown exit offer yet, show it
+        if !hasPurchased && !hasShownExitOffer {
+            hasShownExitOffer = true
+            Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: Showing exit offer")
+
+            // Reset paywall controller for exit offer
+            paywallViewController = nil
+
+            // Show exit offer after a brief delay
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                self?.setupAndPresentPaywall(isExitOffer: true)
+            }
+        } else {
+            // Either they purchased or already saw exit offer - continue
+            if !hasPurchased {
+                Logger.log(level: .info, category: .paywall, message: "🎯 PAYWALL: User declined after exit offer, continuing onboarding")
+            }
+            completePaywallAndContinue()
+        }
     }
 }

--- a/nest-note/Scenes/Onboarding/OnboardingContainerViewController.swift
+++ b/nest-note/Scenes/Onboarding/OnboardingContainerViewController.swift
@@ -95,7 +95,7 @@ final class OnboardingContainerViewController: UIViewController {
     
     private func setupEllipsisMenu() {
         let backToLogin = UIAction(
-            title: "Back to Login",
+            title: "Back to Start",
             image: UIImage(systemName: "arrow.left.circle"),
             attributes: []
         ) { [weak self] _ in

--- a/nest-note/Scenes/Onboarding/OnboardingCoordinator.swift
+++ b/nest-note/Scenes/Onboarding/OnboardingCoordinator.swift
@@ -39,8 +39,14 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
     private weak var delegate: OnboardingCoordinatorDelegate?
     weak var authenticationDelegate: AuthenticationDelegate?
     private var containerViewController: OnboardingContainerViewController!
-    
+
     private var currentStepIndex: Int = 0
+    private var onboardingConfig: OnboardingConfiguration?
+    private var isNavigating: Bool = false
+    private var hasProcessedRoleSelection: Bool = false
+
+    private let configFileName: String
+
     private lazy var steps: [NNOnboardingViewController] = {
         // Start with the new image-based onboarding screens
         var baseSteps: [NNOnboardingViewController] = [
@@ -94,6 +100,21 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
     // Public accessor for role
     var currentRole: NestUser.UserType {
         return userInfo.role
+    }
+
+    // Public accessor for paywall offering based on referral code
+    var paywallOfferingId: String? {
+        // If user has a referral code, show the partner offering
+        if let referralCode = userInfo.referralCode, !referralCode.isEmpty {
+            return "partner"
+        }
+        // Otherwise, use default offering (nil = default)
+        return nil
+    }
+
+    // Public accessor for nest name
+    var currentNestName: String? {
+        return userInfo.nestInfo?.name
     }
     
     // MARK: - Validation Publishers
@@ -197,7 +218,39 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
               validateStep(currentVC) else {
             return
         }
-        
+
+        // Set navigation flag
+        isNavigating = true
+
+        // Track step completion
+        if let stepId = getStepId(for: currentStepIndex) {
+            OnboardingAnalyticsService.shared.recordStepCompleted(stepId)
+        }
+
+        // SPECIAL CASE: Check if we just completed the role_selection survey
+        // If so, update the role and rebuild steps BEFORE navigating
+        if let roleAnswer = userInfo.surveyResponses["role_selection"]?.first,
+           !hasProcessedRoleSelection {
+            Logger.log(level: .info, category: .signup, message: "🎯 NEXT: Processing role_selection in next() method")
+
+            let role: NestUser.UserType
+            if roleAnswer.lowercased() == "parent" || roleAnswer.lowercased() == "nester" {
+                role = .nestOwner
+            } else {
+                role = .sitter
+            }
+
+            // Mark that we've processed this
+            hasProcessedRoleSelection = true
+
+            // Update the role which will rebuild the steps array
+            updateRole(role)
+
+            // After updateRole, the steps array has been rebuilt
+            // currentStepIndex should still point to the role selection step
+            // So we can proceed with incrementing it
+        }
+
         currentStepIndex += 1
         
         if currentStepIndex < allSteps.count {
@@ -486,25 +539,68 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
     
     func updateRole(_ role: NestUser.UserType) {
         userInfo.role = role
-        
-        // Remove any existing survey steps
+
+        Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Selected role: \(role.rawValue)")
+        Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Steps before removal: \(steps.count)")
+
+        // Find the role selection step index (could be OBRoleViewController or a survey VC)
+        var roleSelectionIndex = steps.firstIndex(where: { $0 is OBRoleViewController })
+
+        // If we didn't find OBRoleViewController, look for the first survey step (which is likely role selection from JSON)
+        if roleSelectionIndex == nil {
+            roleSelectionIndex = steps.firstIndex(where: { $0 is NNOnboardingSurveyViewController })
+            Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Role selection is a survey VC at index: \(roleSelectionIndex ?? -1)")
+        }
+
+        // Remove ALL survey steps (including role selection if it's a survey)
         steps.removeAll { $0 is NNOnboardingSurveyViewController }
-        
-        // Add survey questions based on role
+
+        // Remove role-specific steps that shouldn't be in this user's flow
+        if role == .sitter {
+            // Sitters don't need nest creation or paywall
+            steps.removeAll { $0 is OBCreateNestViewController }
+            steps.removeAll { $0 is OBPaywallViewController }
+            Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Removed nest creation and paywall steps for sitter")
+        }
+
+        Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Steps after removal: \(steps.count)")
+
+        // Re-add role selection step if it was a survey-based one from JSON config
+        if let onboardingConfig = onboardingConfig,
+           let roleStep = onboardingConfig.flow.steps.first(where: { $0.id == "role_selection" }) {
+            if case .survey(let surveyConfig) = roleStep.config {
+                let roleVC = createSurveyViewController(from: surveyConfig, stepId: roleStep.id)
+                // Insert at the beginning or where it was found
+                let insertIndex = roleSelectionIndex ?? 0
+                steps.insert(roleVC, at: min(insertIndex, steps.count))
+                Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Re-inserted role selection survey at index: \(insertIndex)")
+            }
+        }
+
+        // Add survey questions based on selected role
         if let surveyConfig = loadSurveyConfig(for: role) {
             let surveySteps = surveyConfig.questions.map { question -> NNOnboardingSurveyViewController in
                 let vc = NNOnboardingSurveyViewController()
                 vc.configure(with: question)
                 return vc
             }
-            
+
+            Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Adding \(surveySteps.count) \(role.rawValue)-specific survey questions")
+
             // Insert survey steps after role selection
-            let roleIndex = steps.firstIndex(where: { $0 is OBRoleViewController }) ?? 0
-            steps.insert(contentsOf: surveySteps, at: roleIndex + 1)
+            let insertionIndex = (roleSelectionIndex ?? 0) + 1
+            steps.insert(contentsOf: surveySteps, at: min(insertionIndex, steps.count))
+        } else {
+            Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: No survey config found for role: \(role.rawValue)")
         }
-        
-        // Update container's total steps count based on new role
-        containerViewController.updateTotalSteps(allSteps.count)
+
+        Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Final step count before ensuring required steps: \(steps.count)")
+
+        // Ensure required steps (like finish) are added based on role
+        // This is critical - without this, sitters won't get the finish step!
+        ensureRequiredStepsExist()
+
+        Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Final step count after ensuring required steps: \(steps.count)")
     }
     
     func updateNestInfo(name: String, address: String) {
@@ -514,6 +610,8 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
     func updateSurveyResponses(_ responses: [String: [String]]) {
         // Merge new responses with existing ones
         userInfo.surveyResponses.merge(responses) { _, new in new }
+
+        // Note: role_selection is handled in next() method to ensure proper navigation timing
     }
     
     func updateReferralCode(_ referralCode: String?) {
@@ -574,30 +672,36 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
     
     func validateRole(_ role: NestUser.UserType) {
         roleValidationSubject.send(true)
-        updateRole(role)
-        
-        // Add required steps to the flow when role is selected
-        ensureRequiredStepsExist()
+        updateRole(role) // This now calls ensureRequiredStepsExist() internally
+
+        // Record role selection in analytics
+        OnboardingAnalyticsService.shared.recordRole(role.rawValue)
     }
     
     private func ensureRequiredStepsExist() {
-        // Add nest creation step for owners if it doesn't exist
-        if userInfo.role == .nestOwner && !steps.contains(where: { $0 is OBCreateNestViewController }) {
-            steps.append(OBCreateNestViewController())
+        // Add role-specific steps
+        if userInfo.role == .nestOwner {
+            // Add nest creation step for owners if it doesn't exist
+            if !steps.contains(where: { $0 is OBCreateNestViewController }) {
+                steps.append(OBCreateNestViewController())
+            }
+
+            // Add paywall step for nest owners (subscription check will happen when step is reached)
+            if !steps.contains(where: { $0 is OBPaywallViewController }) {
+                steps.append(OBPaywallViewController())
+            }
         }
-        
-        // Add paywall step for nest owners only if it doesn't exist
-        if userInfo.role == .nestOwner && !steps.contains(where: { $0 is OBPaywallViewController }) {
-            steps.append(OBPaywallViewController())
-        }
-        
-        // Add finish step if it doesn't exist
+
+        // ALWAYS add finish step for both nest owners AND sitters if it doesn't exist
         if !steps.contains(where: { $0 is OBFinishViewController }) {
             steps.append(OBFinishViewController())
+            Logger.log(level: .info, category: .signup, message: "🎯 ONBOARDING: Added OBFinishViewController to flow for role: \(userInfo.role.rawValue)")
         }
         
         // Update container's step count
         containerViewController.updateTotalSteps(steps.count)
+
+        Logger.log(level: .info, category: .signup, message: "🎯 ONBOARDING: Total steps after role selection: \(steps.count)")
     }
     
     func validateNest(name: String, address: String) {
@@ -789,8 +893,15 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
 // MARK: - OnboardingContainerDelegate
 extension OnboardingCoordinator {
     func onboardingContainerDidRequestAbort(_ container: OnboardingContainerViewController) {
-        // Handle abort - go back to login
-        navigationController.dismiss(animated: true)
+        // Handle abort - go back to landing page
+        // Check if we're pushed on a navigation stack or presented modally
+        if let navController = navigationController.navigationController {
+            // We're pushed, so pop all the way back to the root (LandingViewController)
+            navController.popToRootViewController(animated: true)
+        } else {
+            // We're presented modally (e.g., from Settings), so dismiss
+            navigationController.dismiss(animated: true)
+        }
     }
     
     func onboardingContainerDidRequestSkipSurvey(_ container: OnboardingContainerViewController) {

--- a/nest-note/Scenes/Onboarding/OnboardingCoordinator.swift
+++ b/nest-note/Scenes/Onboarding/OnboardingCoordinator.swift
@@ -40,10 +40,11 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
     private weak var delegate: OnboardingCoordinatorDelegate?
     weak var authenticationDelegate: AuthenticationDelegate?
     private var containerViewController: OnboardingContainerViewController!
-    
+
     private var currentStepIndex: Int = 0
     private var onboardingConfig: OnboardingConfiguration?
     private var isNavigating: Bool = false
+    private var hasProcessedRoleSelection: Bool = false
 
     private let configFileName: String
 
@@ -241,6 +242,16 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
         return userInfo.role
     }
 
+    // Public accessor for paywall offering based on referral code
+    var paywallOfferingId: String? {
+        // If user has a referral code, show the partner offering
+        if let referralCode = userInfo.referralCode, !referralCode.isEmpty {
+            return "partner"
+        }
+        // Otherwise, use default offering (nil = default)
+        return nil
+    }
+
     // Public accessor for nest name
     var currentNestName: String? {
         return userInfo.nestInfo?.name
@@ -384,6 +395,30 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
         // Track step completion
         if let stepId = getStepId(for: currentStepIndex) {
             OnboardingAnalyticsService.shared.recordStepCompleted(stepId)
+        }
+
+        // SPECIAL CASE: Check if we just completed the role_selection survey
+        // If so, update the role and rebuild steps BEFORE navigating
+        if let roleAnswer = userInfo.surveyResponses["role_selection"]?.first,
+           !hasProcessedRoleSelection {
+            Logger.log(level: .info, category: .signup, message: "🎯 NEXT: Processing role_selection in next() method")
+
+            let role: NestUser.UserType
+            if roleAnswer.lowercased() == "parent" || roleAnswer.lowercased() == "nester" {
+                role = .nestOwner
+            } else {
+                role = .sitter
+            }
+
+            // Mark that we've processed this
+            hasProcessedRoleSelection = true
+
+            // Update the role which will rebuild the steps array
+            updateRole(role)
+
+            // After updateRole, the steps array has been rebuilt
+            // currentStepIndex should still point to the role selection step
+            // So we can proceed with incrementing it
         }
 
         currentStepIndex += 1
@@ -739,25 +774,68 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
     
     func updateRole(_ role: NestUser.UserType) {
         userInfo.role = role
-        
-        // Remove any existing survey steps
+
+        Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Selected role: \(role.rawValue)")
+        Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Steps before removal: \(steps.count)")
+
+        // Find the role selection step index (could be OBRoleViewController or a survey VC)
+        var roleSelectionIndex = steps.firstIndex(where: { $0 is OBRoleViewController })
+
+        // If we didn't find OBRoleViewController, look for the first survey step (which is likely role selection from JSON)
+        if roleSelectionIndex == nil {
+            roleSelectionIndex = steps.firstIndex(where: { $0 is NNOnboardingSurveyViewController })
+            Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Role selection is a survey VC at index: \(roleSelectionIndex ?? -1)")
+        }
+
+        // Remove ALL survey steps (including role selection if it's a survey)
         steps.removeAll { $0 is NNOnboardingSurveyViewController }
-        
-        // Add survey questions based on role
+
+        // Remove role-specific steps that shouldn't be in this user's flow
+        if role == .sitter {
+            // Sitters don't need nest creation or paywall
+            steps.removeAll { $0 is OBCreateNestViewController }
+            steps.removeAll { $0 is OBPaywallViewController }
+            Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Removed nest creation and paywall steps for sitter")
+        }
+
+        Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Steps after removal: \(steps.count)")
+
+        // Re-add role selection step if it was a survey-based one from JSON config
+        if let onboardingConfig = onboardingConfig,
+           let roleStep = onboardingConfig.flow.steps.first(where: { $0.id == "role_selection" }) {
+            if case .survey(let surveyConfig) = roleStep.config {
+                let roleVC = createSurveyViewController(from: surveyConfig, stepId: roleStep.id)
+                // Insert at the beginning or where it was found
+                let insertIndex = roleSelectionIndex ?? 0
+                steps.insert(roleVC, at: min(insertIndex, steps.count))
+                Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Re-inserted role selection survey at index: \(insertIndex)")
+            }
+        }
+
+        // Add survey questions based on selected role
         if let surveyConfig = loadSurveyConfig(for: role) {
             let surveySteps = surveyConfig.questions.map { question -> NNOnboardingSurveyViewController in
                 let vc = NNOnboardingSurveyViewController()
                 vc.configure(with: question)
                 return vc
             }
-            
+
+            Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Adding \(surveySteps.count) \(role.rawValue)-specific survey questions")
+
             // Insert survey steps after role selection
-            let roleIndex = steps.firstIndex(where: { $0 is OBRoleViewController }) ?? 0
-            steps.insert(contentsOf: surveySteps, at: roleIndex + 1)
+            let insertionIndex = (roleSelectionIndex ?? 0) + 1
+            steps.insert(contentsOf: surveySteps, at: min(insertionIndex, steps.count))
+        } else {
+            Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: No survey config found for role: \(role.rawValue)")
         }
-        
-        // Update container's total steps count based on new role
-        containerViewController.updateTotalSteps(allSteps.count)
+
+        Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Final step count before ensuring required steps: \(steps.count)")
+
+        // Ensure required steps (like finish) are added based on role
+        // This is critical - without this, sitters won't get the finish step!
+        ensureRequiredStepsExist()
+
+        Logger.log(level: .info, category: .signup, message: "🎯 ROLE UPDATE: Final step count after ensuring required steps: \(steps.count)")
     }
     
     func updateNestInfo(name: String, address: String) {
@@ -772,6 +850,8 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
 
         // Merge new responses with existing ones
         userInfo.surveyResponses.merge(responses) { _, new in new }
+
+        // Note: role_selection is handled in next() method to ensure proper navigation timing
     }
     
     func updateReferralCode(_ referralCode: String?) {
@@ -832,30 +912,36 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
     
     func validateRole(_ role: NestUser.UserType) {
         roleValidationSubject.send(true)
-        updateRole(role)
-        
-        // Add required steps to the flow when role is selected
-        ensureRequiredStepsExist()
+        updateRole(role) // This now calls ensureRequiredStepsExist() internally
+
+        // Record role selection in analytics
+        OnboardingAnalyticsService.shared.recordRole(role.rawValue)
     }
     
     private func ensureRequiredStepsExist() {
-        // Add nest creation step for owners if it doesn't exist
-        if userInfo.role == .nestOwner && !steps.contains(where: { $0 is OBCreateNestViewController }) {
-            steps.append(OBCreateNestViewController())
+        // Add role-specific steps
+        if userInfo.role == .nestOwner {
+            // Add nest creation step for owners if it doesn't exist
+            if !steps.contains(where: { $0 is OBCreateNestViewController }) {
+                steps.append(OBCreateNestViewController())
+            }
+
+            // Add paywall step for nest owners (subscription check will happen when step is reached)
+            if !steps.contains(where: { $0 is OBPaywallViewController }) {
+                steps.append(OBPaywallViewController())
+            }
         }
 
-        // Add paywall step for nest owners (subscription check will happen when step is reached)
-        if userInfo.role == .nestOwner && !steps.contains(where: { $0 is OBPaywallViewController }) {
-            steps.append(OBPaywallViewController())
-        }
-
-        // Add finish step if it doesn't exist
+        // ALWAYS add finish step for both nest owners AND sitters if it doesn't exist
         if !steps.contains(where: { $0 is OBFinishViewController }) {
             steps.append(OBFinishViewController())
+            Logger.log(level: .info, category: .signup, message: "🎯 ONBOARDING: Added OBFinishViewController to flow for role: \(userInfo.role.rawValue)")
         }
 
         // Update container's step count
         containerViewController.updateTotalSteps(steps.count)
+
+        Logger.log(level: .info, category: .signup, message: "🎯 ONBOARDING: Total steps after role selection: \(steps.count)")
     }
 
 
@@ -1105,8 +1191,15 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
 // MARK: - OnboardingContainerDelegate
 extension OnboardingCoordinator {
     func onboardingContainerDidRequestAbort(_ container: OnboardingContainerViewController) {
-        // Handle abort - go back to login
-        navigationController.dismiss(animated: true)
+        // Handle abort - go back to landing page
+        // Check if we're pushed on a navigation stack or presented modally
+        if let navController = navigationController.navigationController {
+            // We're pushed, so pop all the way back to the root (LandingViewController)
+            navController.popToRootViewController(animated: true)
+        } else {
+            // We're presented modally (e.g., from Settings), so dismiss
+            navigationController.dismiss(animated: true)
+        }
     }
     
     func onboardingContainerDidRequestSkipSurvey(_ container: OnboardingContainerViewController) {

--- a/nest-note/Scenes/Sessions/Cells/SessionCell.swift
+++ b/nest-note/Scenes/Sessions/Cells/SessionCell.swift
@@ -72,15 +72,19 @@ class SessionCell: UICollectionViewListCell {
         contentView.backgroundColor = .systemGroupedBackground
     }
     
-//    override func updateConfiguration(using state: UICellConfigurationState) {
-//        super.updateConfiguration(using: state)
-//        
-//        // Update background configuration for current state
-//        var newBgConfig = backgroundConfiguration
-//        newBgConfig?.backgroundColor = state.isSelected ? .systemGray4 : .secondarySystemGroupedBackground
-//        backgroundConfiguration = newBgConfig
-//    }
-    
+    override func updateConfiguration(using state: UICellConfigurationState) {
+        super.updateConfiguration(using: state)
+
+        // Update background configuration to show highlight on tap
+        var newBgConfig = UIBackgroundConfiguration.listCell()
+        if state.isHighlighted || state.isSelected {
+            newBgConfig.backgroundColor = .systemGray4
+        } else {
+            newBgConfig.backgroundColor = .secondarySystemGroupedBackground
+        }
+        backgroundConfiguration = newBgConfig
+    }
+
     private func emptyStateConfig(for section: NestSessionsViewController.Section) -> (message: String, iconName: String) {
         switch section {
         case .inProgress:
@@ -95,27 +99,21 @@ class SessionCell: UICollectionViewListCell {
     func configure(with session: SessionItem) {
         // Hide empty state stack
         emptyStateStack.isHidden = true
-        
-        // Configure background
-        var bgConfig = UIBackgroundConfiguration.listCell()
-        bgConfig.backgroundColor = .secondarySystemGroupedBackground
-        
+
         // Set up content configuration
         var content = UIListContentConfiguration.cell()
-        
+
         // Configure text style
         content.text = session.title
         content.textProperties.font = .bodyL
-        
+
         content.secondaryText = formatDate(startDate: session.startDate, endDate: session.endDate)
         content.secondaryTextProperties.font = .bodyM
         content.secondaryTextProperties.color = .secondaryLabel
-        
+
         // Apply standard system margins
         content.directionalLayoutMargins = .init(top: 12, leading: 16, bottom: 12, trailing: 16)
-        
-        
-        backgroundConfiguration = bgConfig
+
         contentConfiguration = content
         accessories = [.disclosureIndicator()]
     }
@@ -123,37 +121,23 @@ class SessionCell: UICollectionViewListCell {
     func configure(with session: ArchivedSession) {
         // Hide empty state stack
         emptyStateStack.isHidden = true
-        
-        // Configure background
-        var bgConfig = UIBackgroundConfiguration.listCell()
-        bgConfig.backgroundColor = .secondarySystemGroupedBackground
-        
+
         // Set up content configuration
         var content = UIListContentConfiguration.cell()
-        
+
         // Configure text style
         content.text = session.title
         content.textProperties.font = .bodyL
-        
+
         content.secondaryText = formatDate(startDate: session.startDate, endDate: session.endDate)
         content.secondaryTextProperties.font = .bodyM
         content.secondaryTextProperties.color = .secondaryLabel
-        
+
         // Apply standard system margins
         content.directionalLayoutMargins = .init(top: 12, leading: 16, bottom: 12, trailing: 16)
-        
-        backgroundConfiguration = bgConfig
+
         contentConfiguration = content
         accessories = [.disclosureIndicator()]
-    }
-    
-    override var isSelected: Bool {
-        didSet {
-            // Force refresh of background configuration when selection state changes
-            var newBgConfig = backgroundConfiguration
-            newBgConfig?.backgroundColor = isSelected ? .systemGray4 : .secondarySystemGroupedBackground
-            backgroundConfiguration = newBgConfig
-        }
     }
     
     func formatDate(startDate: Date, endDate: Date) -> String {

--- a/nest-note/Scenes/Sessions/Cells/SessionRequestCodeCell.swift
+++ b/nest-note/Scenes/Sessions/Cells/SessionRequestCodeCell.swift
@@ -1,0 +1,122 @@
+import UIKit
+
+protocol SessionRequestCodeCellDelegate: AnyObject {
+    func sessionRequestCodeCellDidTap(inviteCode: String, sessionID: String)
+}
+
+class SessionRequestCodeCell: UICollectionViewListCell {
+    static let reuseIdentifier = "SessionRequestCodeCell"
+
+    weak var delegate: SessionRequestCodeCellDelegate?
+    private var currentInviteCode: String?
+    private var sessionID: String?
+
+    private let iconImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        imageView.tintColor = NNColors.primary
+
+        let symbolConfig = UIImage.SymbolConfiguration(weight: .semibold)
+        imageView.image = UIImage(systemName: "rectangle.fill.badge.plus", withConfiguration: symbolConfig)
+        return imageView
+    }()
+
+    private let nameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bodyL
+        label.textColor = .label
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "Session Request"
+        return label
+    }()
+
+    private lazy var codeLabel: NNPrimaryLabeledButton = {
+        let button = NNPrimaryLabeledButton(
+            title: "000-000",
+            image: nil,
+            backgroundColor: NNColors.primary.withAlphaComponent(0.15),
+            foregroundColor: NNColors.primary
+        )
+        button.isUserInteractionEnabled = true
+        button.addTarget(self, action: #selector(codeButtonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var cellTapGesture: UITapGestureRecognizer = {
+        let gesture = UITapGestureRecognizer(target: self, action: #selector(cellTapped))
+        return gesture
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupViews() {
+        contentView.addSubview(iconImageView)
+        contentView.addSubview(nameLabel)
+        contentView.addSubview(codeLabel)
+
+        // Add tap gesture to the entire cell (excluding the code button)
+        contentView.addGestureRecognizer(cellTapGesture)
+
+        NSLayoutConstraint.activate([
+            iconImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            iconImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            iconImageView.widthAnchor.constraint(equalToConstant: 24),
+            iconImageView.heightAnchor.constraint(equalToConstant: 24),
+
+            nameLabel.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 8),
+            nameLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: codeLabel.leadingAnchor, constant: -8),
+
+            codeLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            codeLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 8),
+            codeLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -8),
+            codeLabel.heightAnchor.constraint(equalToConstant: 40)
+        ])
+    }
+
+    func configure(inviteCode: String, sessionID: String) {
+        self.currentInviteCode = inviteCode
+        self.sessionID = sessionID
+
+        // Format code as 123-456
+        let formattedCode = String(inviteCode.prefix(3)) + "-" + String(inviteCode.suffix(3))
+        codeLabel.setTitle(formattedCode)
+
+        // Add shimmer effect to the code button
+        codeLabel.titleLabel.addShimmerEffect()
+        codeLabel.titleLabel.startShimmer()
+    }
+
+    @objc private func cellTapped(_ gesture: UITapGestureRecognizer) {
+        // Check if tap is not on the code button
+        let location = gesture.location(in: contentView)
+        let codeLabelFrame = codeLabel.frame
+
+        if !codeLabelFrame.contains(location) {
+            // Tap is on the cell but not on the code button
+            guard let code = currentInviteCode, let sessionID = sessionID else { return }
+            delegate?.sessionRequestCodeCellDidTap(inviteCode: code, sessionID: sessionID)
+        }
+    }
+
+    @objc private func codeButtonTapped() {
+        guard let code = currentInviteCode else { return }
+
+        // Copy code to clipboard
+        UIPasteboard.general.string = code
+
+        // Show "Copied" animation (same as SessionInviteSitterCell)
+        codeLabel.showCopiedFeedback()
+
+        // Haptic feedback
+        HapticsHelper.lightHaptic()
+    }
+}

--- a/nest-note/Scenes/Sessions/Cells/SitterSessionCell.swift
+++ b/nest-note/Scenes/Sessions/Cells/SitterSessionCell.swift
@@ -36,15 +36,11 @@ class SitterSessionCell: UICollectionViewListCell {
     }
     
     private func setupViews() {
-        var bgConfig = UIBackgroundConfiguration.listCell()
-        bgConfig.backgroundColor = .secondarySystemGroupedBackground
-        backgroundConfiguration = bgConfig
-        
         // Setup empty state stack
         emptyStateStack.addArrangedSubview(emptyStateLabel)
         emptyStateStack.addArrangedSubview(emptyStateIcon)
         contentView.addSubview(emptyStateStack)
-        
+
         NSLayoutConstraint.activate([
             emptyStateStack.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
             emptyStateStack.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
@@ -53,6 +49,19 @@ class SitterSessionCell: UICollectionViewListCell {
             emptyStateIcon.widthAnchor.constraint(equalToConstant: 12),
             emptyStateIcon.heightAnchor.constraint(equalToConstant: 12)
         ])
+    }
+
+    override func updateConfiguration(using state: UICellConfigurationState) {
+        super.updateConfiguration(using: state)
+
+        // Update background configuration to show highlight on tap
+        var newBgConfig = UIBackgroundConfiguration.listCell()
+        if state.isHighlighted || state.isSelected {
+            newBgConfig.backgroundColor = .systemGray4
+        } else {
+            newBgConfig.backgroundColor = .secondarySystemGroupedBackground
+        }
+        backgroundConfiguration = newBgConfig
     }
     
     func configureEmptyState(for section: SitterSessionsViewController.Section) {
@@ -92,19 +101,22 @@ class SitterSessionCell: UICollectionViewListCell {
     func configure(with session: SessionItem, nestName: String) {
         // Hide empty state stack
         emptyStateStack.isHidden = true
-        
+
         var content = defaultContentConfiguration()
-        
+
+        // Check if this is a session request
+        let isSessionRequest = session.status == .pendingOwnerSetup
+
         // Configure text style
         content.text = session.title
         content.textProperties.font = .bodyL
-        
+
         // Configure date and nest name display
         let dateFormatter = DateFormatter()
         let timeFormatter = DateFormatter()
         timeFormatter.timeStyle = .short
         timeFormatter.dateStyle = .none
-        
+
         let dateString: String
         if session.isMultiDay {
             // For multi-day sessions, show date range without times
@@ -119,15 +131,20 @@ class SitterSessionCell: UICollectionViewListCell {
             let timeString = timeFormatter.string(from: session.startDate)
             dateString = "\(dayString), \(timeString)"
         }
-        
-        // Add nest name to secondary text
-        content.secondaryText = "\(nestName) • \(dateString)"
+
+        // Add nest name and session request indicator to secondary text
+        if isSessionRequest {
+            content.secondaryText = "Session Request • \(dateString)"
+            content.secondaryTextProperties.color = .systemOrange
+        } else {
+            content.secondaryText = "\(nestName) • \(dateString)"
+            content.secondaryTextProperties.color = .secondaryLabel
+        }
         content.secondaryTextProperties.font = .bodyM
-        content.secondaryTextProperties.color = .secondaryLabel
-        
+
         // Apply standard system margins
         content.directionalLayoutMargins = .init(top: 12, leading: 16, bottom: 12, trailing: 16)
-        
+
         contentConfiguration = content
         accessories = [.disclosureIndicator()]
     }
@@ -140,33 +157,26 @@ class SitterSessionCell: UICollectionViewListCell {
     func configureArchived(title: String, date: Date, isArchived: Bool = true) {
         // Hide empty state stack
         emptyStateStack.isHidden = true
-        
+
         var content = defaultContentConfiguration()
-        
+
         // Configure text style
         content.text = title
         content.textProperties.font = .bodyL
-        
+
         // Format date
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "MMM d, yyyy"
         let dateString = dateFormatter.string(from: date)
-        
+
         // Add archived indicator to secondary text
         content.secondaryText = isArchived ? "Completed • \(dateString)" : dateString
         content.secondaryTextProperties.font = .bodyM
         content.secondaryTextProperties.color = .secondaryLabel
-        
+
         // Apply standard system margins
         content.directionalLayoutMargins = .init(top: 12, leading: 16, bottom: 12, trailing: 16)
-        
-        // Add a faded appearance for archived items
-        var bgConfig = backgroundConfiguration ?? UIBackgroundConfiguration.listCell()
-        bgConfig.backgroundColor = isArchived ? 
-            .secondarySystemGroupedBackground.withAlphaComponent(0.8) : 
-            .secondarySystemGroupedBackground
-        backgroundConfiguration = bgConfig
-        
+
         contentConfiguration = content
         accessories = [.disclosureIndicator()]
     }

--- a/nest-note/Scenes/Sessions/CompleteSitterSessionRequestViewController.swift
+++ b/nest-note/Scenes/Sessions/CompleteSitterSessionRequestViewController.swift
@@ -1,0 +1,145 @@
+import UIKit
+
+class CompleteSitterSessionRequestViewController: NNViewController {
+
+    // MARK: - Properties
+
+    private let inviteCode: String
+    private var placeholderSession: SessionItem
+    private let invite: Invite
+
+    private var editSessionVC: EditSessionViewController!
+
+    // MARK: - Lifecycle
+
+    init(inviteCode: String, placeholderSession: SessionItem, invite: Invite) {
+        self.inviteCode = inviteCode
+        self.placeholderSession = placeholderSession
+        self.invite = invite
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .systemBackground
+
+        // Hide navigation bar
+        navigationController?.setNavigationBarHidden(true, animated: false)
+
+        // Sitter info is already in placeholderSession.assignedSitter
+        setupEditSessionViewController()
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // Ensure navigation bar stays hidden
+        navigationController?.setNavigationBarHidden(true, animated: animated)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        // Restore navigation bar when leaving this screen
+        navigationController?.setNavigationBarHidden(false, animated: animated)
+    }
+
+    // MARK: - Setup
+
+    private func setupEditSessionViewController() {
+        // Embed EditSessionViewController as a child
+        editSessionVC = EditSessionViewController(sessionItem: placeholderSession)
+        editSessionVC.delegate = self
+        editSessionVC.isCompletingRequest = true  // Enable completion mode
+
+        addChild(editSessionVC)
+        view.addSubview(editSessionVC.view)
+        editSessionVC.view.frame = view.bounds
+        editSessionVC.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        editSessionVC.didMove(toParent: self)
+    }
+
+    // MARK: - Actions
+
+    private func showSuccessAndDismiss() {
+        let alert = UIAlertController(
+            title: "Session Created!",
+            message: "The session has been added to your nest and the sitter has been notified.",
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(title: "Done", style: .default) { [weak self] _ in
+            // Dismiss all the way back to home
+            self?.presentingViewController?.dismiss(animated: true)
+        })
+
+        present(alert, animated: true)
+    }
+
+    private func showError(_ error: Error) {
+        let alert = UIAlertController(
+            title: "Error",
+            message: error.localizedDescription,
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+}
+
+// MARK: - EditSessionViewControllerDelegate
+
+extension CompleteSitterSessionRequestViewController: EditSessionViewControllerDelegate {
+    func editSessionViewController(_ controller: EditSessionViewController, didCreateSession session: SessionItem) {
+        // Parent completed the form - now accept the request
+        Task {
+            do {
+                // Get sitter info from the session's assignedSitter (already populated)
+                guard let assignedSitter = session.assignedSitter else {
+                    throw SessionError.sessionNotFound
+                }
+
+                let sitterInfo = (
+                    name: assignedSitter.name,
+                    email: assignedSitter.email,
+                    userID: assignedSitter.userID ?? invite.createdBy
+                )
+
+                try await SessionService.shared.acceptSitterSessionRequest(
+                    inviteCode: inviteCode,
+                    completedSession: session,
+                    sitterInfo: sitterInfo
+                )
+
+                await MainActor.run {
+                    // Stop loading button with success animation
+                    self.editSessionVC.saveButton.stopLoading(withSuccess: true)
+                    
+                    // Post notification so SessionsViewController can reload
+                    NotificationCenter.default.post(name: .sessionDidChange, object: nil)
+                    
+                    // Small delay to show success animation before dismissing
+                    Task {
+                        try? await Task.sleep(for: .seconds(0.75))
+                        await MainActor.run {
+                            self.showSuccessAndDismiss()
+                        }
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    // Stop loading button with failure
+                    self.editSessionVC.saveButton.stopLoading(withSuccess: false)
+                    self.showError(error)
+                }
+            }
+        }
+    }
+
+    func editSessionViewController(_ controller: EditSessionViewController, didUpdateSession session: SessionItem) {
+        // Not used in request completion flow
+    }
+}

--- a/nest-note/Scenes/Sessions/CreateSessionRequestViewController.swift
+++ b/nest-note/Scenes/Sessions/CreateSessionRequestViewController.swift
@@ -1,0 +1,614 @@
+import UIKit
+import FirebaseAuth
+
+protocol CreateSessionRequestViewControllerDelegate: AnyObject {
+    func createSessionRequestViewController(_ controller: CreateSessionRequestViewController, didCreateRequest inviteCode: String, sessionID: String)
+}
+
+class CreateSessionRequestViewController: NNViewController {
+
+    // MARK: - Section & Item Enums
+
+    enum Section: Hashable {
+        case inviteCode
+        case nest
+        case date
+    }
+
+    enum Item: Hashable {
+        case inviteCode(code: String)
+        case nestSelection(id: String?, name: String)
+        case dateSelection(startDate: Date, endDate: Date, isMultiDay: Bool)
+    }
+
+    // MARK: - Properties
+
+    weak var delegate: CreateSessionRequestViewControllerDelegate?
+
+    private var collectionView: UICollectionView!
+    private var dataSource: UICollectionViewDiffableDataSource<Section, Item>!
+
+    private let titleTextField: FlashingPlaceholderTextField = {
+        let placeholders = [
+            "Date Night",
+            "Weekend Getaway",
+            "Evening Out",
+            "Family Event"
+        ]
+        let field = FlashingPlaceholderTextField(placeholders: placeholders)
+        field.font = .h2
+        field.borderStyle = .none
+        field.returnKeyType = .done
+        field.translatesAutoresizingMaskIntoConstraints = false
+        return field
+    }()
+
+    private lazy var createButton: NNLoadingButton = {
+        let button = NNLoadingButton(title: "Create Request", titleColor: .white, fillStyle: .fill(NNColors.primary))
+        button.addTarget(self, action: #selector(createButtonTapped), for: .touchUpInside)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private var availableNests: [(id: String, name: String)] = []
+    private var selectedNest: (id: String, name: String)?
+
+    private var startDate: Date = Date().roundedToNextHour()
+    private var endDate: Date = Date().addingTimeInterval(3 * 60 * 60).roundedToNextHour()
+    private var isMultiDay: Bool = false
+
+    // Viewing mode properties
+    private var isViewingMode: Bool = false
+    private var inviteCode: String?
+    private var sessionID: String?
+    private var pendingTitle: String?
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .systemBackground
+
+        // Hide navigation bar for this view controller
+        navigationItem.preferredNavigationBarVisibility = .hidden
+
+        titleTextField.delegate = self
+    }
+
+    override func setup() {
+        super.setup()
+
+        setupCollectionView()
+        setupNavigationBar()
+        setupDataSource()
+        applyInitialSnapshot()
+
+        if !isViewingMode {
+            loadAvailableNests()
+        } else {
+            // In viewing mode, set the title and disable editing
+            if let title = pendingTitle {
+                titleTextField.text = title
+            }
+            titleTextField.isEnabled = false
+            createButton.isHidden = true
+        }
+
+        createButton.pinToBottom(of: view, addBlurEffect: true, blurRadius: 16, blurMaskImage: UIImage(named: "testBG3"))
+    }
+
+    // MARK: - Configuration
+
+    func configure(with session: SessionItem, inviteCode: String, nestName: String) {
+        self.isViewingMode = true
+        self.inviteCode = inviteCode
+        self.sessionID = session.id
+        self.startDate = session.startDate
+        self.endDate = session.endDate
+        self.isMultiDay = session.isMultiDay
+        // Handle empty nestID - set to nil if empty string
+        if session.nestID.isEmpty {
+            self.selectedNest = nil
+        } else {
+            self.selectedNest = (id: session.nestID, name: nestName)
+        }
+        self.pendingTitle = session.title
+
+        // Update UI if already loaded
+        if isViewLoaded {
+            titleTextField.text = session.title
+            titleTextField.isEnabled = false
+            createButton.isHidden = true
+            applyInitialSnapshot()
+        }
+    }
+
+    // MARK: - Setup
+
+    private func setupNavigationBar() {
+        // Create custom navigation bar
+        let customNavBar = UIView()
+        customNavBar.backgroundColor = .tertiarySystemGroupedBackground
+        customNavBar.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(customNavBar)
+
+        // Add title text field
+        titleTextField.translatesAutoresizingMaskIntoConstraints = false
+        customNavBar.addSubview(titleTextField)
+
+        // Add close button
+        let closeButton = UIButton(type: .system)
+        closeButton.setImage(UIImage(systemName: "xmark"), for: .normal)
+        closeButton.tintColor = .systemGray
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        closeButton.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+        customNavBar.addSubview(closeButton)
+
+        // Add separator view
+        let separatorView = UIView()
+        separatorView.backgroundColor = .separator
+        separatorView.translatesAutoresizingMaskIntoConstraints = false
+        customNavBar.addSubview(separatorView)
+
+        NSLayoutConstraint.activate([
+            customNavBar.topAnchor.constraint(equalTo: view.topAnchor),
+            customNavBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            customNavBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            customNavBar.heightAnchor.constraint(equalToConstant: 66),
+
+            titleTextField.leadingAnchor.constraint(equalTo: customNavBar.leadingAnchor, constant: 24),
+            titleTextField.centerYAnchor.constraint(equalTo: customNavBar.centerYAnchor, constant: 0),
+            titleTextField.trailingAnchor.constraint(equalTo: closeButton.leadingAnchor, constant: -16),
+
+            closeButton.trailingAnchor.constraint(equalTo: customNavBar.trailingAnchor, constant: -16),
+            closeButton.centerYAnchor.constraint(equalTo: customNavBar.centerYAnchor, constant: 0),
+            closeButton.widthAnchor.constraint(equalToConstant: 28),
+            closeButton.heightAnchor.constraint(equalToConstant: 28),
+
+            // Separator constraints
+            separatorView.leadingAnchor.constraint(equalTo: customNavBar.leadingAnchor),
+            separatorView.trailingAnchor.constraint(equalTo: customNavBar.trailingAnchor),
+            separatorView.bottomAnchor.constraint(equalTo: customNavBar.bottomAnchor),
+            separatorView.heightAnchor.constraint(equalToConstant: 0.5)
+        ])
+
+        // Update collection view constraints
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: customNavBar.bottomAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+
+    private func setupCollectionView() {
+        let layout = createLayout()
+        collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: layout)
+        collectionView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+
+        // Ensure selection is enabled
+        collectionView.allowsSelection = true
+        collectionView.allowsMultipleSelection = false
+
+        let insets = UIEdgeInsets(
+            top: 20,
+            left: 0,
+            bottom: 100, // Increased to accommodate button height + padding
+            right: 0
+        )
+
+        // Add bottom inset to accommodate the pinned button
+        collectionView.contentInset = insets
+        collectionView.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: insets.bottom - 30, right: 0)
+
+        view.addSubview(collectionView)
+
+        // Set delegate and other properties after collection view is fully configured
+        collectionView.delegate = self
+        collectionView.delaysContentTouches = false
+    }
+
+    private func createLayout() -> UICollectionViewLayout {
+        let layout = UICollectionViewCompositionalLayout { sectionIndex, layoutEnvironment in
+            var config = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
+
+            // Enable footer
+            config.footerMode = .supplementary
+
+            let section = NSCollectionLayoutSection.list(using: config, layoutEnvironment: layoutEnvironment)
+            section.contentInsets = NSDirectionalEdgeInsets(top: 4, leading: 18, bottom: 4, trailing: 18)
+            return section
+        }
+        return layout
+    }
+
+    private func setupDataSource() {
+        let inviteCodeRegistration = UICollectionView.CellRegistration<SessionRequestCodeCell, Item> { [weak self] cell, indexPath, item in
+            guard let self else { return }
+            if case let .inviteCode(code) = item {
+                if let sessionID = self.sessionID {
+                    cell.configure(inviteCode: code, sessionID: sessionID)
+                    cell.delegate = self
+                }
+            }
+        }
+
+        let nestRegistration = UICollectionView.CellRegistration<NestNameCell, Item> { [weak self] cell, indexPath, item in
+            guard let self else { return }
+            if case let .nestSelection(_, name) = item {
+                cell.configure(with: name)
+            }
+        }
+
+        let dateRegistration = UICollectionView.CellRegistration<DateCell, Item> { [weak self] cell, indexPath, item in
+            guard let self else { return }
+            if case let .dateSelection(startDate, endDate, isMultiDay) = item {
+                cell.configure(startDate: startDate, endDate: endDate, isMultiDay: isMultiDay, isReadOnly: self.isViewingMode)
+                cell.delegate = self
+            }
+        }
+
+        // Register footer
+        let footerRegistration = UICollectionView.SupplementaryRegistration<UICollectionViewListCell>(
+            elementKind: UICollectionView.elementKindSectionFooter
+        ) { supplementaryView, elementKind, indexPath in
+            var configuration = supplementaryView.defaultContentConfiguration()
+
+            // Configure footer based on section
+            switch self.dataSource.sectionIdentifier(for: indexPath.section) {
+            case .date:
+                configuration.text = "Send this request to a Nest Owner. They'll receive an invite code and can accept your session or adjust the dates and times as needed."
+                configuration.textProperties.numberOfLines = 0
+            default:
+                break
+            }
+
+            configuration.textProperties.font = .preferredFont(forTextStyle: .footnote)
+            configuration.textProperties.color = .tertiaryLabel
+            configuration.textProperties.alignment = .center
+
+            supplementaryView.contentConfiguration = configuration
+        }
+
+        dataSource = UICollectionViewDiffableDataSource<Section, Item>(collectionView: collectionView) { collectionView, indexPath, item in
+            switch item {
+            case .inviteCode:
+                return collectionView.dequeueConfiguredReusableCell(using: inviteCodeRegistration, for: indexPath, item: item)
+            case .nestSelection:
+                return collectionView.dequeueConfiguredReusableCell(using: nestRegistration, for: indexPath, item: item)
+            case .dateSelection:
+                return collectionView.dequeueConfiguredReusableCell(using: dateRegistration, for: indexPath, item: item)
+            }
+        }
+
+        // Add supplementary view provider to data source
+        dataSource.supplementaryViewProvider = { collectionView, kind, indexPath in
+            return collectionView.dequeueConfiguredReusableSupplementary(
+                using: footerRegistration,
+                for: indexPath
+            )
+        }
+    }
+
+    private func applyInitialSnapshot() {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
+
+        // Add invite code section first if in viewing mode
+        if isViewingMode, let code = inviteCode {
+            snapshot.appendSections([.inviteCode])
+            snapshot.appendItems([.inviteCode(code: code)], toSection: .inviteCode)
+        }
+
+        snapshot.appendSections([.nest, .date])
+
+        // Nest section - always show, even if no nest selected
+        if let nest = selectedNest {
+            snapshot.appendItems([.nestSelection(id: nest.id, name: nest.name)], toSection: .nest)
+        } else {
+            snapshot.appendItems([.nestSelection(id: nil, name: "No nest selected")], toSection: .nest)
+        }
+
+        // Date section
+        snapshot.appendItems([.dateSelection(startDate: startDate, endDate: endDate, isMultiDay: isMultiDay)], toSection: .date)
+
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+
+    private func updateSnapshot() {
+        var snapshot = dataSource.snapshot()
+
+        // Update nest - always show, even if no nest selected
+        snapshot.deleteItems(snapshot.itemIdentifiers(inSection: .nest))
+        if let nest = selectedNest {
+            snapshot.appendItems([.nestSelection(id: nest.id, name: nest.name)], toSection: .nest)
+        } else {
+            snapshot.appendItems([.nestSelection(id: nil, name: "No nest selected")], toSection: .nest)
+        }
+
+        // Update date
+        snapshot.deleteItems(snapshot.itemIdentifiers(inSection: .date))
+        snapshot.appendItems([.dateSelection(startDate: startDate, endDate: endDate, isMultiDay: isMultiDay)], toSection: .date)
+
+        dataSource.apply(snapshot, animatingDifferences: true)
+    }
+
+    // MARK: - Data Loading
+
+    private func loadAvailableNests() {
+        guard let userID = Auth.auth().currentUser?.uid else {
+            showError("Not authenticated")
+            return
+        }
+
+        Task {
+            do {
+                // Fetch sitter sessions to get nest info
+                let sitterSessionsRef = SessionService.shared.db.collection("users").document(userID)
+                    .collection("sitterSessions")
+                let snapshot = try await sitterSessionsRef.getDocuments()
+
+                var nestMap: [String: String] = [:]
+                for doc in snapshot.documents {
+                    if let sitterSession = try? doc.data(as: SitterSession.self) {
+                        nestMap[sitterSession.nestID] = sitterSession.nestName
+                    }
+                }
+
+                await MainActor.run {
+                    self.availableNests = nestMap.map { (id: $0.key, name: $0.value) }
+                        .sorted { $0.name < $1.name }
+
+                    // Don't auto-select a nest - let user choose or leave it unselected
+                    self.updateSnapshot()
+                }
+            } catch {
+                Logger.log(level: .error, category: .sessionService, message: "Failed to load nests: \(error.localizedDescription)")
+                await MainActor.run {
+                    self.showError("Failed to load nests")
+                }
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    @objc private func cancelTapped() {
+        dismiss(animated: true)
+    }
+
+    @objc private func createButtonTapped() {
+        guard let title = titleTextField.text, !title.isEmpty else {
+            showError("Please enter a session title")
+            return
+        }
+
+        // Nest selection is optional - allow nil
+        let nest = selectedNest
+
+        // Validate dates using unified validation logic
+        guard SessionDateValidator.validateAndShowAlertIfNeeded(startDate: startDate, endDate: endDate, in: self) else {
+            return
+        }
+
+        createButton.startLoading()
+
+        Task {
+            do {
+                let (code, sessionID) = try await SessionService.shared.createSitterSessionRequest(
+                    title: title,
+                    startDate: startDate,
+                    endDate: endDate,
+                    targetNestID: nest?.id,
+                    targetNestName: nest?.name
+                )
+
+                await MainActor.run {
+                    self.createButton.stopLoading(withSuccess: true)
+                    self.delegate?.createSessionRequestViewController(self, didCreateRequest: code, sessionID: sessionID)
+                }
+            } catch {
+                await MainActor.run {
+                    self.createButton.stopLoading(withSuccess: false)
+                    self.showError("Failed to create session request: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func showError(_ message: String) {
+        let alert = UIAlertController(title: "Error", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+}
+
+// MARK: - UICollectionViewDelegate
+
+extension CreateSessionRequestViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        collectionView.deselectItem(at: indexPath, animated: true)
+        guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
+
+        switch item {
+        case .inviteCode:
+            // Handled by SessionRequestCodeCell
+            break
+        case .nestSelection:
+            if !isViewingMode {
+                showNestPicker()
+            }
+        case .dateSelection:
+            break // Handled by DateCell delegate
+        }
+    }
+
+    private func showNestPicker() {
+        let alert = UIAlertController(title: "Select Nest", message: nil, preferredStyle: .actionSheet)
+
+        // Add "None" option to allow deselecting
+        let noneAction = UIAlertAction(title: "None", style: .default) { [weak self] _ in
+            self?.selectedNest = nil
+            self?.updateSnapshot()
+        }
+        alert.addAction(noneAction)
+
+        for nest in availableNests {
+            let action = UIAlertAction(title: nest.name, style: .default) { [weak self] _ in
+                self?.selectedNest = nest
+                self?.updateSnapshot()
+            }
+            alert.addAction(action)
+        }
+
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+
+        if let popover = alert.popoverPresentationController {
+            popover.sourceView = collectionView
+            if let cell = collectionView.cellForItem(at: IndexPath(item: 0, section: 0)) {
+                popover.sourceRect = cell.frame
+            }
+        }
+
+        present(alert, animated: true)
+    }
+}
+
+// MARK: - DatePresentationDelegate
+
+extension CreateSessionRequestViewController: DatePresentationDelegate {
+    func presentDatePicker(for type: NNDateTimePickerSheet.PickerType, initialDate: Date) {
+        let mode: UIDatePicker.Mode = type == .startDate || type == .endDate ? .date : .time
+
+        let pickerVC = NNDateTimePickerSheet(
+            mode: mode,
+            type: type,
+            initialDate: initialDate,
+            interval: 15
+        )
+        pickerVC.delegate = self
+
+        let nav = UINavigationController(rootViewController: pickerVC)
+        if let sheet = nav.sheetPresentationController {
+            sheet.detents = [.custom(resolver: { context in
+                    return 280
+            })]
+            sheet.prefersGrabberVisible = true
+            sheet.preferredCornerRadius = 24
+        }
+
+        present(nav, animated: true)
+    }
+
+    func didToggleMultiDay(_ isMultiDay: Bool, startDate: Date, endDate: Date) {
+        self.isMultiDay = isMultiDay
+        self.startDate = startDate
+
+        if isMultiDay {
+            // When enabling multi-day, set end date to start date + 1 day as default
+            self.endDate = Calendar.current.date(byAdding: .day, value: 1, to: startDate) ?? endDate
+
+            // Enable multi-day on the cell after updating dates
+            if let dateCell = getCellForSection(.date) as? DateCell {
+                dateCell.enableMultiDay()
+            }
+        } else {
+            // When disabling multi-day, sync end date to use start date's day with end time
+            self.endDate = Date.syncEndDateToStartDay(startDate: startDate, endDate: endDate) ?? endDate
+        }
+
+        updateSnapshot()
+    }
+
+    private func getCellForSection(_ section: Section) -> UICollectionViewCell? {
+        guard let sectionIndex = dataSource.snapshot().indexOfSection(section),
+              let firstItem = dataSource.snapshot().itemIdentifiers(inSection: section).first,
+              let indexPath = dataSource.indexPath(for: firstItem) else {
+            return nil
+        }
+        return collectionView.cellForItem(at: indexPath)
+    }
+
+    func didChangeEarlyAccess(_ duration: EarlyAccessDuration) {
+        // Not used in request creation - parent sets this
+    }
+}
+
+// MARK: - NNDateTimePickerSheetDelegate
+
+extension CreateSessionRequestViewController: NNDateTimePickerSheetDelegate {
+    func dateTimePickerSheet(_ sheet: NNDateTimePickerSheet, didSelectDate date: Date) {
+        let previousStartDate = startDate
+        let result = SessionDateSynchronizer.synchronizeDates(
+            pickerType: sheet.pickerType,
+            newDate: date,
+            previousStartDate: previousStartDate,
+            currentEndDate: endDate,
+            isMultiDay: isMultiDay
+        )
+        
+        // Validate the synchronized dates using unified validation logic
+        guard SessionDateValidator.validateAndShowAlertIfNeeded(startDate: result.adjustedStartDate, endDate: result.adjustedEndDate, isMultiDay: isMultiDay, in: self) else {
+            return // Don't update dates if invalid
+        }
+        
+        startDate = result.adjustedStartDate
+        endDate = result.adjustedEndDate
+        
+        updateSnapshot()
+    }
+}
+
+// MARK: - UITextFieldDelegate
+
+extension CreateSessionRequestViewController: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+}
+
+// MARK: - SessionRequestCodeCellDelegate
+
+extension CreateSessionRequestViewController: SessionRequestCodeCellDelegate {
+    func sessionRequestCodeCellDidTap(inviteCode: String, sessionID: String) {
+        // Push to InviteDetailViewController
+        let inviteVC = InviteDetailViewController()
+        inviteVC.configure(
+            with: inviteCode,
+            sessionID: sessionID,
+            sitter: nil,
+            isSitterInitiated: true
+        )
+        inviteVC.delegate = self
+        navigationController?.pushViewController(inviteVC, animated: true)
+    }
+}
+
+// MARK: - InviteSitterViewControllerDelegate
+
+extension CreateSessionRequestViewController: InviteSitterViewControllerDelegate {
+    func inviteSitterViewControllerDidSendInvite(to sitter: SitterItem, inviteId: String) {
+        // Not applicable for session requests - invites are created during request creation
+    }
+    
+    func inviteSitterViewControllerDidCancel() {
+        // Not applicable for session requests
+    }
+    
+    func inviteDetailViewControllerDidDeleteInvite() {
+        // When the invite is deleted, the session request is also cancelled
+        // Post notification to refresh the sessions list and dismiss this view controller
+        NotificationCenter.default.post(name: .sessionDidChange, object: nil)
+        
+        // Dismiss this view controller since the session request no longer exists
+        if let navController = navigationController {
+            navController.dismiss(animated: true)
+        } else {
+            dismiss(animated: true)
+        }
+    }
+}

--- a/nest-note/Scenes/Sessions/EditSessionViewController.swift
+++ b/nest-note/Scenes/Sessions/EditSessionViewController.swift
@@ -87,14 +87,24 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
     private var pdfURL: URL?
     private let maxVisibleEvents = 4
     
+    // Add property to track if completing a sitter-initiated request
+    var isCompletingRequest: Bool = false
+
     // Add property for save button
-    private lazy var saveButton: NNLoadingButton = {
-        let buttonTitle = isEditingSession ? "Save Changes" : "Next"
+    lazy var saveButton: NNLoadingButton = {
+        let buttonTitle: String
+        if isCompletingRequest {
+            buttonTitle = "Create Session"
+        } else if isEditingSession {
+            buttonTitle = "Save Changes"
+        } else {
+            buttonTitle = "Next"
+        }
         let button = NNLoadingButton(title: buttonTitle, titleColor: .white, fillStyle: .fill(NNColors.primary))
         button.addTarget(self, action: #selector(saveButtonTapped), for: .touchUpInside)
         return button
     }()
-    
+
     // Add property to track if this is an archived session
     var isArchivedSession: Bool = false {
         didSet {
@@ -106,8 +116,8 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
             }
         }
     }
-    
-    
+
+
     weak var delegate: EditSessionViewControllerDelegate?
     
     // MARK: - PaywallPresentable
@@ -309,6 +319,37 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
             dataSource.apply(newSnapshot, animatingDifferences: false)
         }
         
+        // If completing a request with multi-day, validate subscription and disable if needed
+        if isCompletingRequest && sessionItem.isMultiDay {
+            Task {
+                let hasMultiDaySessions = await SubscriptionService.shared.isFeatureAvailable(.multiDaySessions)
+                if !hasMultiDaySessions {
+                    await MainActor.run {
+                        // Force to single-day: sync end date to same day as start date
+                        let syncedEndDate = Date.syncEndDateToStartDay(startDate: sessionItem.startDate, endDate: sessionItem.endDate) ?? sessionItem.endDate
+                        sessionItem.isMultiDay = false
+                        sessionItem.endDate = syncedEndDate
+                        
+                        // Update the date selection in the UI
+                        if let dateItem = dataSource.snapshot().itemIdentifiers(inSection: .date).first,
+                           case .dateSelection = dateItem {
+                            var newSnapshot = dataSource.snapshot()
+                            newSnapshot.deleteItems([dateItem])
+                            newSnapshot.appendItems([.dateSelection(
+                                startDate: sessionItem.startDate,
+                                endDate: syncedEndDate,
+                                isMultiDay: false
+                            )], toSection: .date)
+                            dataSource.apply(newSnapshot, animatingDifferences: false)
+                            
+                            // Revert the toggle in the DateCell if it exists
+                            self.revertDateCellMultiDayToggle()
+                        }
+                    }
+                }
+            }
+        }
+        
         // Pre-populate other fields if editing
         // Note: visibilityLevel is no longer used, using selectedEntries instead
         
@@ -355,7 +396,7 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
             customNavBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             customNavBar.heightAnchor.constraint(equalToConstant: 66),
             
-            titleTextField.leadingAnchor.constraint(equalTo: customNavBar.leadingAnchor, constant: 16),
+            titleTextField.leadingAnchor.constraint(equalTo: customNavBar.leadingAnchor, constant: 24),
             titleTextField.centerYAnchor.constraint(equalTo: customNavBar.centerYAnchor, constant: 0),
             titleTextField.trailingAnchor.constraint(equalTo: closeButton.leadingAnchor, constant: -16),
             
@@ -564,27 +605,51 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
     @objc override func closeButtonTapped() {
         // Check for unsaved changes before dismissing
         if hasUnsavedChanges {
+            let alertTitle: String
+            let alertMessage: String
+
+            if isCompletingRequest {
+                alertTitle = "Cancel Session Setup?"
+                alertMessage = "The session request won't be accepted if you leave now."
+            } else {
+                alertTitle = "Discard Changes?"
+                alertMessage = "You have unsaved changes. Are you sure you want to discard them?"
+            }
+
             let alert = UIAlertController(
-                title: "Discard Changes?",
-                message: "You have unsaved changes. Are you sure you want to discard them?",
+                title: alertTitle,
+                message: alertMessage,
                 preferredStyle: .alert
             )
-            
+
             alert.addAction(UIAlertAction(
                 title: "Keep Editing",
                 style: .cancel
             ))
-            
+
             alert.addAction(UIAlertAction(
-                title: "Discard Changes",
+                title: isCompletingRequest ? "Cancel" : "Discard Changes",
                 style: .destructive
             ) { [weak self] _ in
-                self?.dismiss(animated: true)
+                guard let self = self else { return }
+                if self.isCompletingRequest && self.navigationController != nil {
+                    // If embedded in a nav controller during request completion, pop
+                    self.navigationController?.popViewController(animated: true)
+                } else {
+                    // Otherwise dismiss normally
+                    self.dismiss(animated: true)
+                }
             })
-            
+
             present(alert, animated: true)
         } else {
-            dismiss(animated: true)
+            if isCompletingRequest && navigationController != nil {
+                // If embedded in a nav controller during request completion, pop
+                navigationController?.popViewController(animated: true)
+            } else {
+                // Otherwise dismiss normally
+                dismiss(animated: true)
+            }
         }
     }
     
@@ -682,8 +747,19 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
                 }
                 
                 // Validate date range logic (same as SessionEventViewController)
-                guard validateDateRange(startDate: startDate, endDate: endDate) else {
+                guard validateDateRange(startDate: startDate, endDate: endDate, isMultiDay: isMultiDay) else {
                     return
+                }
+                
+                // Validate multi-day subscription requirement
+                if isMultiDay {
+                    let hasMultiDaySessions = await SubscriptionService.shared.isFeatureAvailable(.multiDaySessions)
+                    if !hasMultiDaySessions {
+                        await MainActor.run {
+                            self.showMultiDayUpgradePrompt()
+                        }
+                        return
+                    }
                 }
                 
                 // Update existing sessionItem with new values
@@ -695,13 +771,37 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
                 // Note: visibilityLevel is no longer used, replaced by selectedEntries
                 sessionItem.ownerID = NestService.shared.currentNest?.ownerId
                 
+                // Ensure nestID is set (critical for completing sitter requests)
+                if let currentNest = NestService.shared.currentNest {
+                    sessionItem.nestID = currentNest.id
+                } else if sessionItem.nestID.isEmpty {
+                    // Fallback: use nestID from invite if available
+                    // This should not happen in normal flow, but provides safety
+                    Logger.log(level: .error, category: .sessionService, message: "No current nest available when completing request")
+                }
+                
                 // Store selected item IDs in the session
                 if !selectedItemIds.isEmpty {
                     sessionItem.entryIds = selectedItemIds
                 } else {
                     sessionItem.entryIds = nil // Clear entryIds if no items selected
                 }
-                
+
+                if isCompletingRequest {
+                    // Validate nestID is set before proceeding
+                    guard !sessionItem.nestID.isEmpty else {
+                        showToast(text: "Please select a nest", sentiment: .negative)
+                        return
+                    }
+                    
+                    // Start loading button before notifying delegate
+                    saveButton.startLoading()
+                    
+                    // Just notify delegate - parent VC handles acceptance
+                    delegate?.editSessionViewController(self, didCreateSession: sessionItem)
+                    return
+                }
+
                 if isEditingSession {
                     try await updateSession()
                 } else {
@@ -1753,34 +1853,8 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
         HapticsHelper.lightHaptic()
     }
     
-    private func validateDateRange(startDate: Date, endDate: Date) -> Bool {
-        let calendar = Calendar.current
-        
-        // Check if start date is after end date
-        if calendar.compare(startDate, to: endDate, toGranularity: .minute) == .orderedDescending {
-            let alert = UIAlertController(
-                title: "Invalid Time Range",
-                message: "The start time cannot be after the end time.",
-                preferredStyle: .alert
-            )
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
-            present(alert, animated: true)
-            return false
-        }
-        
-        // Check if start and end times are the same
-        if calendar.compare(startDate, to: endDate, toGranularity: .minute) == .orderedSame {
-            let alert = UIAlertController(
-                title: "Invalid Time Range",
-                message: "The start and end times cannot be the same.",
-                preferredStyle: .alert
-            )
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
-            present(alert, animated: true)
-            return false
-        }
-        
-        return true
+    private func validateDateRange(startDate: Date, endDate: Date, isMultiDay: Bool) -> Bool {
+        return SessionDateValidator.validateAndShowAlertIfNeeded(startDate: startDate, endDate: endDate, isMultiDay: isMultiDay, in: self)
     }
     
     private func validateSession() -> Bool {
@@ -1794,7 +1868,7 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
         }
         
         // Check if dates are valid using the same logic as validateDateRange
-        if !validateDateRange(startDate: sessionItem.startDate, endDate: sessionItem.endDate) {
+        if !validateDateRange(startDate: sessionItem.startDate, endDate: sessionItem.endDate, isMultiDay: sessionItem.isMultiDay) {
             return false
         }
         
@@ -2315,33 +2389,16 @@ extension EditSessionViewController: NNDateTimePickerSheetDelegate {
         guard let snapshot = dataSource.snapshot().itemIdentifiers(inSection: .date).first,
               case let .dateSelection(startDate, endDate, isMultiDay) = snapshot else { return }
         
-        var newStartDate = startDate
-        var newEndDate = endDate
         let currentMultiDayState = isMultiDay
         
-        switch sheet.pickerType {
-        case .startDate, .startTime:
-            newStartDate = date
-            if !isMultiDay {
-                // Sync end date with start date while preserving end time
-                let calendar = Calendar.current
-                let startComponents = calendar.dateComponents([.year, .month, .day], from: date)
-                let endTimeComponents = calendar.dateComponents([.hour, .minute], from: endDate)
-                
-                var newComponents = DateComponents()
-                newComponents.year = startComponents.year
-                newComponents.month = startComponents.month
-                newComponents.day = startComponents.day
-                newComponents.hour = endTimeComponents.hour
-                newComponents.minute = endTimeComponents.minute
-                
-                if let syncedEndDate = calendar.date(from: newComponents) {
-                    newEndDate = syncedEndDate
-                }
-            }
-        case .endDate, .endTime:
-            newEndDate = date
-        }
+        // Use centralized date synchronization utility
+        let result = SessionDateSynchronizer.synchronizeDates(
+            pickerType: sheet.pickerType,
+            newDate: date,
+            previousStartDate: startDate,
+            currentEndDate: endDate,
+            isMultiDay: isMultiDay
+        )
         
         // Update the data source
         let dateItems = dataSource.snapshot().itemIdentifiers(inSection: .date)
@@ -2350,13 +2407,13 @@ extension EditSessionViewController: NNDateTimePickerSheetDelegate {
         newSnapshot.deleteItems(dateItems)
         
         // Add date selection to date section
-        newSnapshot.appendItems([.dateSelection(startDate: newStartDate, endDate: newEndDate, isMultiDay: currentMultiDayState)], toSection: .date)
+        newSnapshot.appendItems([.dateSelection(startDate: result.adjustedStartDate, endDate: result.adjustedEndDate, isMultiDay: currentMultiDayState)], toSection: .date)
         dataSource.apply(newSnapshot, animatingDifferences: false)
         
         // Check if we need to apply a pending status change
         if let pendingStatus = pendingStatusChange {
             // Validate that the new end date is in the future if we're changing to active status
-            if (pendingStatus == .inProgress || pendingStatus == .upcoming) && newEndDate > Date() {
+            if (pendingStatus == .inProgress || pendingStatus == .upcoming) && result.adjustedEndDate > Date() {
                 pendingStatusChange = nil
                 applyStatusChange(pendingStatus)
             }

--- a/nest-note/Scenes/Sessions/EditSessionViewController.swift
+++ b/nest-note/Scenes/Sessions/EditSessionViewController.swift
@@ -87,14 +87,24 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
     private var pdfURL: URL?
     private let maxVisibleEvents = 4
     
+    // Add property to track if completing a sitter-initiated request
+    var isCompletingRequest: Bool = false
+
     // Add property for save button
-    private lazy var saveButton: NNLoadingButton = {
-        let buttonTitle = isEditingSession ? "Save Changes" : "Next"
+    lazy var saveButton: NNLoadingButton = {
+        let buttonTitle: String
+        if isCompletingRequest {
+            buttonTitle = "Create Session"
+        } else if isEditingSession {
+            buttonTitle = "Save Changes"
+        } else {
+            buttonTitle = "Next"
+        }
         let button = NNLoadingButton(title: buttonTitle, titleColor: .white, fillStyle: .fill(NNColors.primary))
         button.addTarget(self, action: #selector(saveButtonTapped), for: .touchUpInside)
         return button
     }()
-    
+
     // Add property to track if this is an archived session
     var isArchivedSession: Bool = false {
         didSet {
@@ -106,8 +116,8 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
             }
         }
     }
-    
-    
+
+
     weak var delegate: EditSessionViewControllerDelegate?
     
     // MARK: - PaywallPresentable
@@ -309,6 +319,37 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
             dataSource.apply(newSnapshot, animatingDifferences: false)
         }
         
+        // If completing a request with multi-day, validate subscription and disable if needed
+        if isCompletingRequest && sessionItem.isMultiDay {
+            Task {
+                let hasMultiDaySessions = await SubscriptionService.shared.isFeatureAvailable(.multiDaySessions)
+                if !hasMultiDaySessions {
+                    await MainActor.run {
+                        // Force to single-day: sync end date to same day as start date
+                        let syncedEndDate = Date.syncEndDateToStartDay(startDate: sessionItem.startDate, endDate: sessionItem.endDate) ?? sessionItem.endDate
+                        sessionItem.isMultiDay = false
+                        sessionItem.endDate = syncedEndDate
+                        
+                        // Update the date selection in the UI
+                        if let dateItem = dataSource.snapshot().itemIdentifiers(inSection: .date).first,
+                           case .dateSelection = dateItem {
+                            var newSnapshot = dataSource.snapshot()
+                            newSnapshot.deleteItems([dateItem])
+                            newSnapshot.appendItems([.dateSelection(
+                                startDate: sessionItem.startDate,
+                                endDate: syncedEndDate,
+                                isMultiDay: false
+                            )], toSection: .date)
+                            dataSource.apply(newSnapshot, animatingDifferences: false)
+                            
+                            // Revert the toggle in the DateCell if it exists
+                            self.revertDateCellMultiDayToggle()
+                        }
+                    }
+                }
+            }
+        }
+        
         // Pre-populate other fields if editing
         // Note: visibilityLevel is no longer used, using selectedEntries instead
         
@@ -355,7 +396,7 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
             customNavBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             customNavBar.heightAnchor.constraint(equalToConstant: 66),
             
-            titleTextField.leadingAnchor.constraint(equalTo: customNavBar.leadingAnchor, constant: 16),
+            titleTextField.leadingAnchor.constraint(equalTo: customNavBar.leadingAnchor, constant: 24),
             titleTextField.centerYAnchor.constraint(equalTo: customNavBar.centerYAnchor, constant: 0),
             titleTextField.trailingAnchor.constraint(equalTo: closeButton.leadingAnchor, constant: -16),
             
@@ -564,27 +605,51 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
     @objc override func closeButtonTapped() {
         // Check for unsaved changes before dismissing
         if hasUnsavedChanges {
+            let alertTitle: String
+            let alertMessage: String
+
+            if isCompletingRequest {
+                alertTitle = "Cancel Session Setup?"
+                alertMessage = "The session request won't be accepted if you leave now."
+            } else {
+                alertTitle = "Discard Changes?"
+                alertMessage = "You have unsaved changes. Are you sure you want to discard them?"
+            }
+
             let alert = UIAlertController(
-                title: "Discard Changes?",
-                message: "You have unsaved changes. Are you sure you want to discard them?",
+                title: alertTitle,
+                message: alertMessage,
                 preferredStyle: .alert
             )
-            
+
             alert.addAction(UIAlertAction(
                 title: "Keep Editing",
                 style: .cancel
             ))
-            
+
             alert.addAction(UIAlertAction(
-                title: "Discard Changes",
+                title: isCompletingRequest ? "Cancel" : "Discard Changes",
                 style: .destructive
             ) { [weak self] _ in
-                self?.dismiss(animated: true)
+                guard let self = self else { return }
+                if self.isCompletingRequest && self.navigationController != nil {
+                    // If embedded in a nav controller during request completion, pop
+                    self.navigationController?.popViewController(animated: true)
+                } else {
+                    // Otherwise dismiss normally
+                    self.dismiss(animated: true)
+                }
             })
-            
+
             present(alert, animated: true)
         } else {
-            dismiss(animated: true)
+            if isCompletingRequest && navigationController != nil {
+                // If embedded in a nav controller during request completion, pop
+                navigationController?.popViewController(animated: true)
+            } else {
+                // Otherwise dismiss normally
+                dismiss(animated: true)
+            }
         }
     }
     
@@ -682,8 +747,19 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
                 }
                 
                 // Validate date range logic (same as SessionEventViewController)
-                guard validateDateRange(startDate: startDate, endDate: endDate) else {
+                guard validateDateRange(startDate: startDate, endDate: endDate, isMultiDay: isMultiDay) else {
                     return
+                }
+                
+                // Validate multi-day subscription requirement
+                if isMultiDay {
+                    let hasMultiDaySessions = await SubscriptionService.shared.isFeatureAvailable(.multiDaySessions)
+                    if !hasMultiDaySessions {
+                        await MainActor.run {
+                            self.showMultiDayUpgradePrompt()
+                        }
+                        return
+                    }
                 }
                 
                 // Update existing sessionItem with new values
@@ -695,13 +771,37 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
                 // Note: visibilityLevel is no longer used, replaced by selectedEntries
                 sessionItem.ownerID = NestService.shared.currentNest?.ownerId
                 
+                // Ensure nestID is set (critical for completing sitter requests)
+                if let currentNest = NestService.shared.currentNest {
+                    sessionItem.nestID = currentNest.id
+                } else if sessionItem.nestID.isEmpty {
+                    // Fallback: use nestID from invite if available
+                    // This should not happen in normal flow, but provides safety
+                    Logger.log(level: .error, category: .sessionService, message: "No current nest available when completing request")
+                }
+                
                 // Store selected item IDs in the session
                 if !selectedItemIds.isEmpty {
                     sessionItem.entryIds = selectedItemIds
                 } else {
                     sessionItem.entryIds = nil // Clear entryIds if no items selected
                 }
-                
+
+                if isCompletingRequest {
+                    // Validate nestID is set before proceeding
+                    guard !sessionItem.nestID.isEmpty else {
+                        showToast(text: "Please select a nest", sentiment: .negative)
+                        return
+                    }
+                    
+                    // Start loading button before notifying delegate
+                    saveButton.startLoading()
+                    
+                    // Just notify delegate - parent VC handles acceptance
+                    delegate?.editSessionViewController(self, didCreateSession: sessionItem)
+                    return
+                }
+
                 if isEditingSession {
                     try await updateSession()
                 } else {
@@ -1710,34 +1810,8 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
         HapticsHelper.lightHaptic()
     }
     
-    private func validateDateRange(startDate: Date, endDate: Date) -> Bool {
-        let calendar = Calendar.current
-        
-        // Check if start date is after end date
-        if calendar.compare(startDate, to: endDate, toGranularity: .minute) == .orderedDescending {
-            let alert = UIAlertController(
-                title: "Invalid Time Range",
-                message: "The start time cannot be after the end time.",
-                preferredStyle: .alert
-            )
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
-            present(alert, animated: true)
-            return false
-        }
-        
-        // Check if start and end times are the same
-        if calendar.compare(startDate, to: endDate, toGranularity: .minute) == .orderedSame {
-            let alert = UIAlertController(
-                title: "Invalid Time Range",
-                message: "The start and end times cannot be the same.",
-                preferredStyle: .alert
-            )
-            alert.addAction(UIAlertAction(title: "OK", style: .default))
-            present(alert, animated: true)
-            return false
-        }
-        
-        return true
+    private func validateDateRange(startDate: Date, endDate: Date, isMultiDay: Bool) -> Bool {
+        return SessionDateValidator.validateAndShowAlertIfNeeded(startDate: startDate, endDate: endDate, isMultiDay: isMultiDay, in: self)
     }
     
     private func validateSession() -> Bool {
@@ -1751,7 +1825,7 @@ class EditSessionViewController: NNViewController, PaywallPresentable, PaywallVi
         }
         
         // Check if dates are valid using the same logic as validateDateRange
-        if !validateDateRange(startDate: sessionItem.startDate, endDate: sessionItem.endDate) {
+        if !validateDateRange(startDate: sessionItem.startDate, endDate: sessionItem.endDate, isMultiDay: sessionItem.isMultiDay) {
             return false
         }
         
@@ -2272,33 +2346,16 @@ extension EditSessionViewController: NNDateTimePickerSheetDelegate {
         guard let snapshot = dataSource.snapshot().itemIdentifiers(inSection: .date).first,
               case let .dateSelection(startDate, endDate, isMultiDay) = snapshot else { return }
         
-        var newStartDate = startDate
-        var newEndDate = endDate
         let currentMultiDayState = isMultiDay
         
-        switch sheet.pickerType {
-        case .startDate, .startTime:
-            newStartDate = date
-            if !isMultiDay {
-                // Sync end date with start date while preserving end time
-                let calendar = Calendar.current
-                let startComponents = calendar.dateComponents([.year, .month, .day], from: date)
-                let endTimeComponents = calendar.dateComponents([.hour, .minute], from: endDate)
-                
-                var newComponents = DateComponents()
-                newComponents.year = startComponents.year
-                newComponents.month = startComponents.month
-                newComponents.day = startComponents.day
-                newComponents.hour = endTimeComponents.hour
-                newComponents.minute = endTimeComponents.minute
-                
-                if let syncedEndDate = calendar.date(from: newComponents) {
-                    newEndDate = syncedEndDate
-                }
-            }
-        case .endDate, .endTime:
-            newEndDate = date
-        }
+        // Use centralized date synchronization utility
+        let result = SessionDateSynchronizer.synchronizeDates(
+            pickerType: sheet.pickerType,
+            newDate: date,
+            previousStartDate: startDate,
+            currentEndDate: endDate,
+            isMultiDay: isMultiDay
+        )
         
         // Update the data source
         let dateItems = dataSource.snapshot().itemIdentifiers(inSection: .date)
@@ -2307,13 +2364,13 @@ extension EditSessionViewController: NNDateTimePickerSheetDelegate {
         newSnapshot.deleteItems(dateItems)
         
         // Add date selection to date section
-        newSnapshot.appendItems([.dateSelection(startDate: newStartDate, endDate: newEndDate, isMultiDay: currentMultiDayState)], toSection: .date)
+        newSnapshot.appendItems([.dateSelection(startDate: result.adjustedStartDate, endDate: result.adjustedEndDate, isMultiDay: currentMultiDayState)], toSection: .date)
         dataSource.apply(newSnapshot, animatingDifferences: false)
         
         // Check if we need to apply a pending status change
         if let pendingStatus = pendingStatusChange {
             // Validate that the new end date is in the future if we're changing to active status
-            if (pendingStatus == .inProgress || pendingStatus == .upcoming) && newEndDate > Date() {
+            if (pendingStatus == .inProgress || pendingStatus == .upcoming) && result.adjustedEndDate > Date() {
                 pendingStatusChange = nil
                 applyStatusChange(pendingStatus)
             }

--- a/nest-note/Scenes/Sessions/SessionEventViewController.swift
+++ b/nest-note/Scenes/Sessions/SessionEventViewController.swift
@@ -442,18 +442,24 @@ final class SessionEventViewController: NNSheetViewController {
         let startDate = startControl.date
         let endDate = endControl.date
         
-        if calendar.compare(startDate, to: endDate, toGranularity: .minute) == .orderedDescending {
+        // Use unified validation logic (events are always single-day, allowing overnight)
+        let validationResult = SessionDateValidator.validateDateRange(startDate: startDate, endDate: endDate, isMultiDay: false)
+        
+        switch validationResult {
+        case .valid:
+            break // Continue with additional validations
+        case .invalidStartAfterEnd:
+            // Show error alert using unified method
             let alert = UIAlertController(
-                title: "Invalid Time Range",
-                message: "The start time cannot be after the end time.",
+                title: validationResult.errorTitle,
+                message: validationResult.errorMessage,
                 preferredStyle: .alert
             )
             alert.addAction(UIAlertAction(title: "OK", style: .default))
             present(alert, animated: true)
             return false
-        }
-        
-        if calendar.compare(startDate, to: endDate, toGranularity: .minute) == .orderedSame {
+        case .invalidSameTime:
+            // For events, auto-adjust end time to be 1 hour after start time
             endControl.date = calendar.date(byAdding: .hour, value: 1, to: startDate) ?? startDate
         }
         

--- a/nest-note/Scenes/Sessions/SessionRequestSuccessViewController.swift
+++ b/nest-note/Scenes/Sessions/SessionRequestSuccessViewController.swift
@@ -1,0 +1,184 @@
+import UIKit
+
+class SessionRequestSuccessViewController: NNViewController {
+
+    // MARK: - Properties
+
+    private let inviteCode: String
+
+    private let successImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "checkmark.circle.fill")
+        imageView.tintColor = NNColors.primary
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Request Created!"
+        label.font = .h1
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Share this code with the parent"
+        label.font = .preferredFont(forTextStyle: .body)
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var codeLabel: UILabel = {
+        let label = UILabel()
+        label.text = inviteCode
+        label.font = UIFont.monospacedSystemFont(ofSize: 48, weight: .bold)
+        label.textAlignment = .center
+        label.textColor = NNColors.primary
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let codeContainerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .secondarySystemGroupedBackground
+        view.layer.cornerRadius = 16
+        view.layer.borderWidth = 2
+        view.layer.borderColor = NNColors.primary.cgColor
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private lazy var copyButton: NNLoadingButton = {
+        let button = NNLoadingButton(title: "Copy Code", titleColor: .white, fillStyle: .fill(NNColors.primary))
+        button.addTarget(self, action: #selector(copyButtonTapped), for: .touchUpInside)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private lazy var shareButton: NNLoadingButton = {
+        let button = NNLoadingButton(title: "Share Code", titleColor: .white, fillStyle: .fill(NNColors.primary))
+        button.addTarget(self, action: #selector(shareButtonTapped), for: .touchUpInside)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private lazy var doneButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Done", for: .normal)
+        button.titleLabel?.font = .preferredFont(forTextStyle: .body)
+        button.setTitleColor(.secondaryLabel, for: .normal)
+        button.addTarget(self, action: #selector(doneButtonTapped), for: .touchUpInside)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    // MARK: - Lifecycle
+
+    init(inviteCode: String) {
+        self.inviteCode = inviteCode
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .systemBackground
+        navigationItem.hidesBackButton = true
+
+        setupUI()
+    }
+
+    // MARK: - Setup
+
+    private func setupUI() {
+        codeContainerView.addSubview(codeLabel)
+
+        view.addSubview(successImageView)
+        view.addSubview(titleLabel)
+        view.addSubview(subtitleLabel)
+        view.addSubview(codeContainerView)
+        view.addSubview(copyButton)
+        view.addSubview(shareButton)
+        view.addSubview(doneButton)
+
+        NSLayoutConstraint.activate([
+            successImageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 60),
+            successImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            successImageView.widthAnchor.constraint(equalToConstant: 80),
+            successImageView.heightAnchor.constraint(equalToConstant: 80),
+
+            titleLabel.topAnchor.constraint(equalTo: successImageView.bottomAnchor, constant: 24),
+            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40),
+            titleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -40),
+
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 12),
+            subtitleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40),
+            subtitleLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -40),
+
+            codeContainerView.topAnchor.constraint(equalTo: subtitleLabel.bottomAnchor, constant: 40),
+            codeContainerView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 40),
+            codeContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -40),
+            codeContainerView.heightAnchor.constraint(equalToConstant: 120),
+
+            codeLabel.centerXAnchor.constraint(equalTo: codeContainerView.centerXAnchor),
+            codeLabel.centerYAnchor.constraint(equalTo: codeContainerView.centerYAnchor),
+
+            copyButton.topAnchor.constraint(equalTo: codeContainerView.bottomAnchor, constant: 32),
+            copyButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            copyButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            copyButton.heightAnchor.constraint(equalToConstant: 50),
+
+            shareButton.topAnchor.constraint(equalTo: copyButton.bottomAnchor, constant: 12),
+            shareButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            shareButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            shareButton.heightAnchor.constraint(equalToConstant: 50),
+
+            doneButton.topAnchor.constraint(equalTo: shareButton.bottomAnchor, constant: 24),
+            doneButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            doneButton.heightAnchor.constraint(equalToConstant: 44)
+        ])
+    }
+
+    // MARK: - Actions
+
+    @objc private func copyButtonTapped() {
+        UIPasteboard.general.string = inviteCode
+
+        // Show feedback
+        copyButton.setTitle("Copied!")
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+
+        // Reset after delay
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            self?.copyButton.setTitle("Copy Code")
+        }
+    }
+
+    @objc private func shareButtonTapped() {
+        let message = "Join my session on NestNote with code: \(inviteCode)"
+        let activityVC = UIActivityViewController(activityItems: [message], applicationActivities: nil)
+
+        if let popover = activityVC.popoverPresentationController {
+            popover.sourceView = shareButton
+            popover.sourceRect = shareButton.bounds
+        }
+
+        present(activityVC, animated: true)
+    }
+
+    @objc private func doneButtonTapped() {
+        // Dismiss back to sitter home
+        dismiss(animated: true)
+    }
+}

--- a/nest-note/Scenes/Sessions/SessionsViewController.swift
+++ b/nest-note/Scenes/Sessions/SessionsViewController.swift
@@ -55,7 +55,7 @@ class NestSessionsViewController: NNViewController {
         }
     }
     
-    private var filterSegmentedControl: UISegmentedControl!
+    private var filterSegmentedControl: NNSegmentedFilterView!
     internal var loadingIndicator: UIActivityIndicatorView!
     internal var refreshControl: UIRefreshControl!
     
@@ -128,10 +128,20 @@ class NestSessionsViewController: NNViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupNotificationObservers()
+        // Ensure navigation bar is configured before adding palette
+        setupNavigationBar()
+        // Create filter view early so it exists when we need to enable/disable it during fetch
+        createFilterSegmentedControl()
         loadSessions()
 
         // Set initial filter to inProgress
         currentBucket = .inProgress
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // Add palette to navigation bar after view is laid out
+        addPaletteToNavigationBar()
         filterSegmentedControl.selectedSegmentIndex = 1 // inProgress is at index 1
     }
     
@@ -195,11 +205,11 @@ class NestSessionsViewController: NNViewController {
     
     override func setup() {
         title = "Nest Sessions"
-        setupFilterSegmentedControl()
         setupCollectionView()
         setupEmptyStateView()
         setupNewSessionButton()
         configureDataSource()
+        setupNavigationBar()
 
         // Add loading spinner
         view.addSubview(loadingSpinner)
@@ -209,41 +219,39 @@ class NestSessionsViewController: NNViewController {
         ])
     }
     
-    private func setupFilterSegmentedControl() {
-        filterSegmentedControl = UISegmentedControl(items: ["Past", "In Progress", "Upcoming"])
-        filterSegmentedControl.selectedSegmentIndex = 1 // Default to "In Progress"
-        filterSegmentedControl.addTarget(self, action: #selector(segmentedControlValueChanged), for: .valueChanged)
-
-        // Create a container view for the segmented control with proper sizing
-        let containerView = UIView()
-        containerView.addSubview(filterSegmentedControl)
-        filterSegmentedControl.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            filterSegmentedControl.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
-            filterSegmentedControl.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
-            filterSegmentedControl.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 8),
-            filterSegmentedControl.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -8),
-            filterSegmentedControl.heightAnchor.constraint(equalToConstant: 32)
-        ])
-
-        containerView.frame.size.height = 48
-        addNavigationBarPalette(containerView)
+    private func setupNavigationBar() {
+        // Configure navigation bar appearance
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithDefaultBackground()
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.standardAppearance = appearance
     }
-
-    @objc private func segmentedControlValueChanged() {
-        let selectedIndex = filterSegmentedControl.selectedSegmentIndex
-        let newBucket: SessionService.SessionBucket
-
-        switch selectedIndex {
-        case 0: newBucket = .past
-        case 1: newBucket = .inProgress
-        case 2: newBucket = .upcoming
-        default: newBucket = .inProgress
-        }
-
-        currentBucket = newBucket
-        updateDisplayedSessions()
+    
+    override func setupNavigationBarButtons() {
+        let findButton = UIBarButtonItem(
+            title: "Join",
+            style: .plain,
+            target: self,
+            action: #selector(findSessionTapped)
+        )
+        findButton.tintColor = .label
+        navigationItem.rightBarButtonItem = findButton
+    }
+    
+    private func createFilterSegmentedControl() {
+        // Only create once
+        guard filterSegmentedControl == nil else { return }
+        
+        filterSegmentedControl = NNSegmentedFilterView(items: ["Past", "In Progress", "Upcoming"])
+        filterSegmentedControl.delegate = self
+        filterSegmentedControl.selectedSegmentIndex = 1 // Default to "In Progress"
+        filterSegmentedControl.frame.size.height = 48
+    }
+    
+    private func addPaletteToNavigationBar() {
+        // Only add once - check if already added by checking if view has a window
+        guard filterSegmentedControl.window == nil else { return }
+        addNavigationBarPalette(filterSegmentedControl)
     }
     
     private func setupCollectionView() {
@@ -546,6 +554,14 @@ class NestSessionsViewController: NNViewController {
         present(UINavigationController(rootViewController: vc), animated: true)
     }
     
+    @objc private func findSessionTapped() {
+        let findVC = JoinSessionViewController()
+        findVC.delegate = self
+        let nav = UINavigationController(rootViewController: findVC)
+        nav.modalPresentationStyle = .formSheet
+        present(nav, animated: true)
+    }
+    
     // Helper method to delete a session
     private func deleteSession(_ session: SessionItem, completion: @escaping (Bool) -> Void) {
         Task {
@@ -699,6 +715,10 @@ extension NestSessionsViewController: EditSessionViewControllerDelegate {
         case .completed, .archived:
             currentBucket = .past
             filterSegmentedControl.selectedSegmentIndex = 0
+        case .pendingOwnerSetup:
+            // Pending sessions shouldn't appear in this view
+            currentBucket = .upcoming
+            filterSegmentedControl.selectedSegmentIndex = 2
         }
     }
     
@@ -772,5 +792,29 @@ extension NestSessionsViewController: CollectionViewLoadable {
                 Logger.log(level: .error, category: .sessionService, message: "Error loading sessions: \(error.localizedDescription)")
             }
         }
+    }
+}
+
+extension NestSessionsViewController: JoinSessionViewControllerDelegate {
+    func joinSessionViewController(didAcceptInvite session: SitterSession) {
+        // Refresh sessions list to include the newly accepted one
+        loadSessions()
+        showToast(text: "Session added successfully")
+    }
+}
+
+extension NestSessionsViewController: NNSegmentedFilterViewDelegate {
+    func segmentedFilterView(_ filterView: NNSegmentedFilterView, didSelectSegmentAtIndex index: Int) {
+        let newBucket: SessionService.SessionBucket
+
+        switch index {
+        case 0: newBucket = .past
+        case 1: newBucket = .inProgress
+        case 2: newBucket = .upcoming
+        default: newBucket = .inProgress
+        }
+
+        currentBucket = newBucket
+        updateDisplayedSessions()
     }
 } 

--- a/nest-note/Scenes/Sessions/SitterSessionDetailViewController.swift
+++ b/nest-note/Scenes/Sessions/SitterSessionDetailViewController.swift
@@ -204,7 +204,7 @@ final class SitterSessionDetailViewController: NNViewController {
             customNavBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             customNavBar.heightAnchor.constraint(equalToConstant: 66),
             
-            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
             stackView.centerYAnchor.constraint(equalTo: customNavBar.centerYAnchor),
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
             

--- a/nest-note/Scenes/Sessions/SitterSessionsViewController.swift
+++ b/nest-note/Scenes/Sessions/SitterSessionsViewController.swift
@@ -32,7 +32,7 @@ class SitterSessionsViewController: NNViewController {
         case empty(Section)
     }
     
-    private var filterSegmentedControl: UISegmentedControl!
+    private var filterSegmentedControl: NNSegmentedFilterView!
     internal var loadingIndicator: UIActivityIndicatorView!
     internal var refreshControl: UIRefreshControl!
     
@@ -59,7 +59,7 @@ class SitterSessionsViewController: NNViewController {
         case .upcoming:
             return allSessions
                 .compactMap { $0 as? SessionItem }
-                .filter { $0.status == .upcoming }
+                .filter { $0.status == .upcoming || $0.status == .pendingOwnerSetup }
                 .sorted { $0.startDate < $1.startDate }
         case .inProgress:
             return allSessions
@@ -104,15 +104,45 @@ class SitterSessionsViewController: NNViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupNotificationObservers()
+        // Ensure navigation bar is configured before adding palette
+        setupNavigationBar()
+        // Create filter view early so it exists when we need to enable/disable it during fetch
+        createFilterSegmentedControl()
         loadSessions()
         
+        // Set initial filter to inProgress
         currentBucket = .inProgress
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // Add palette to navigation bar after view is laid out
+        addPaletteToNavigationBar()
         filterSegmentedControl.selectedSegmentIndex = 1 // inProgress is at index 1
+    }
+    
+    private func setupNotificationObservers() {
+        // Listen for session changes to refresh the list
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleSessionDidChange),
+            name: .sessionDidChange,
+            object: nil
+        )
+    }
+    
+    @objc private func handleSessionDidChange() {
+        // Refresh the sessions list when a session changes
+        loadSessions()
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
     
     override func setup() {
         title = "My Sessions"
-        setupFilterSegmentedControl()
         setupCollectionView()
         setupEmptyStateView()
         setupJoinSessionButton()
@@ -126,44 +156,39 @@ class SitterSessionsViewController: NNViewController {
         ])
     }
     
-    private func setupFilterSegmentedControl() {
-        filterSegmentedControl = UISegmentedControl(items: ["Past", "In Progress", "Upcoming"])
-        filterSegmentedControl.selectedSegmentIndex = 1 // Default to "In Progress"
-        filterSegmentedControl.addTarget(self, action: #selector(segmentedControlValueChanged), for: .valueChanged)
-
-        // Create a container view for the segmented control with proper sizing
-        let containerView = UIView()
-        containerView.addSubview(filterSegmentedControl)
-        filterSegmentedControl.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            filterSegmentedControl.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 16),
-            filterSegmentedControl.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -16),
-            filterSegmentedControl.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 8),
-            filterSegmentedControl.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -8),
-            filterSegmentedControl.heightAnchor.constraint(equalToConstant: 32)
-        ])
-
-        containerView.frame.size.height = 48
-        addNavigationBarPalette(containerView)
-
-        // Set initial filter to inProgress
-        currentBucket = .inProgress
+    private func setupNavigationBar() {
+        // Configure navigation bar appearance
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithDefaultBackground()
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        navigationController?.navigationBar.standardAppearance = appearance
     }
-
-    @objc private func segmentedControlValueChanged() {
-        let selectedIndex = filterSegmentedControl.selectedSegmentIndex
-        let newBucket: SessionService.SessionBucket
-
-        switch selectedIndex {
-        case 0: newBucket = .past
-        case 1: newBucket = .inProgress
-        case 2: newBucket = .upcoming
-        default: newBucket = .inProgress
-        }
-
-        currentBucket = newBucket
-        updateDisplayedSessions()
+    
+    override func setupNavigationBarButtons() {
+        let createButton = UIBarButtonItem(
+            image: UIImage(systemName: "plus"),
+            style: .plain,
+            target: self,
+            action: #selector(createSessionTapped)
+        )
+        createButton.tintColor = .label
+        navigationItem.rightBarButtonItem = createButton
+    }
+    
+    private func createFilterSegmentedControl() {
+        // Only create once
+        guard filterSegmentedControl == nil else { return }
+        
+        filterSegmentedControl = NNSegmentedFilterView(items: ["Past", "In Progress", "Upcoming"])
+        filterSegmentedControl.delegate = self
+        filterSegmentedControl.selectedSegmentIndex = 1 // Default to "In Progress"
+        filterSegmentedControl.frame.size.height = 48
+    }
+    
+    private func addPaletteToNavigationBar() {
+        // Only add once - check if already added by checking if view has a window
+        guard filterSegmentedControl.window == nil else { return }
+        addNavigationBarPalette(filterSegmentedControl)
     }
     
     private func setupCollectionView() {
@@ -175,18 +200,26 @@ class SitterSessionsViewController: NNViewController {
                 return nil
             }
             
+            // Determine if this is a session request or regular session
+            let isSessionRequest = session.status == .pendingOwnerSetup
+            
             let deleteAction = UIContextualAction(
                 style: .destructive,
-                title: "Remove"
+                title: isSessionRequest ? "Cancel" : "Remove"
             ) { [weak self] _, _, completion in
                 guard let self = self else {
                     completion(false)
                     return
                 }
                 
+                let alertTitle = isSessionRequest ? "Cancel Session Request" : "Remove Session"
+                let alertMessage = isSessionRequest 
+                    ? "Are you sure you want to cancel this session request? The invite will be cancelled and the nest owner will no longer be able to accept it."
+                    : "Are you sure you want to remove this session? You may need to be reinvited to see it again."
+                
                 let alert = UIAlertController(
-                    title: "Remove Session",
-                    message: "Are you sure you want to remove this session? You may need to be reinvited to see it again.",
+                    title: alertTitle,
+                    message: alertMessage,
                     preferredStyle: .alert
                 )
                 
@@ -197,11 +230,16 @@ class SitterSessionsViewController: NNViewController {
                     completion(false)
                 })
                 
+                let confirmTitle = isSessionRequest ? "Cancel Request" : "Remove"
                 alert.addAction(UIAlertAction(
-                    title: "Remove",
+                    title: confirmTitle,
                     style: .destructive
                 ) { _ in
-                    self.deleteSessionAction(session, completion: completion)
+                    if isSessionRequest {
+                        self.deleteSessionRequestAction(session, completion: completion)
+                    } else {
+                        self.deleteSessionAction(session, completion: completion)
+                    }
                 })
                 
                 self.present(alert, animated: true)
@@ -247,11 +285,9 @@ class SitterSessionsViewController: NNViewController {
                 cell.configure(with: session, nestName: "")
                 
                 // Then fetch the actual nest name
-                Task {
+                Task { @MainActor in
                     if let sitterSession = try? await self?.sessionService.getSitterSession(sessionID: session.id) {
-                        await MainActor.run {
-                            cell.configure(with: session, nestName: sitterSession.nestName)
-                        }
+                        cell.configure(with: session, nestName: sitterSession.nestName)
                     }
                 }
                 
@@ -341,17 +377,20 @@ class SitterSessionsViewController: NNViewController {
     private func fetchSitterSessions() {
         Task {
             do {
-                filterSegmentedControl.isEnabled = false
-                emptyStateView.hideImmediately()
-                loadingSpinner.startAnimating()
+                await MainActor.run {
+                    filterSegmentedControl.isEnabled = false
+                    emptyStateView.hideImmediately()
+                    loadingSpinner.startAnimating()
+                }
                 guard let userID = UserService.shared.currentUser?.id else { return }
-                
-                // Fetch both active sitter sessions and archived ones
+
+                // Fetch active sitter sessions, archived ones, and pending session requests
                 async let regularSessionsTask = sessionService.fetchSitterSessions(userID: userID)
                 async let archivedSessionsTask = sessionService.fetchArchivedSitterSessions(userID: userID)
-                
-                let (collection, archivedSessions) = try await (regularSessionsTask, archivedSessionsTask)
-                
+                async let sessionRequestsTask = sessionService.fetchSitterSessionRequests(userID: userID)
+
+                let (collection, archivedSessions, sessionRequests) = try await (regularSessionsTask, archivedSessionsTask, sessionRequestsTask)
+
                 await MainActor.run {
                     filterSegmentedControl.isEnabled = true
                     var allSessionItems: [Any] = []
@@ -359,7 +398,8 @@ class SitterSessionsViewController: NNViewController {
                     allSessionItems.append(contentsOf: collection.inProgress)
                     allSessionItems.append(contentsOf: collection.past)
                     allSessionItems.append(contentsOf: archivedSessions)
-                    
+                    allSessionItems.append(contentsOf: sessionRequests)  // Add pending requests
+
                     self.allSessions = allSessionItems
                     updateEmptyState()
                     self.loadingSpinner.stopAnimating()
@@ -391,16 +431,42 @@ class SitterSessionsViewController: NNViewController {
         Task {
             do {
                 try await self.sessionService.deleteSitterSession(sessionID: session.id)
+                // Remove the session from the data source
                 await MainActor.run {
-                    // Remove the session from the data source
                     var snapshot = self.dataSource.snapshot()
                     snapshot.deleteItems([.session(session)])
                     self.dataSource.apply(snapshot, animatingDifferences: true)
+                    // Update allSessions to reflect the deletion
+                    self.allSessions.removeAll { ($0 as? SessionItem)?.id == session.id }
                     completion(true)
                 }
             } catch {
                 print("Error deleting session: \(error)")
-                completion(false)
+                await MainActor.run {
+                    completion(false)
+                }
+            }
+        }
+    }
+    
+    private func deleteSessionRequestAction(_ session: SessionItem, completion: @escaping (Bool) -> Void) {
+        Task {
+            do {
+                try await self.sessionService.cancelSitterSessionRequest(sessionID: session.id)
+                // Remove the session request from the data source
+                await MainActor.run {
+                    var snapshot = self.dataSource.snapshot()
+                    snapshot.deleteItems([.session(session)])
+                    self.dataSource.apply(snapshot, animatingDifferences: true)
+                    // Update allSessions to reflect the deletion
+                    self.allSessions.removeAll { ($0 as? SessionItem)?.id == session.id }
+                    completion(true)
+                }
+            } catch {
+                print("Error cancelling session request: \(error)")
+                await MainActor.run {
+                    completion(false)
+                }
             }
         }
     }
@@ -408,7 +474,17 @@ class SitterSessionsViewController: NNViewController {
     @objc private func joinSessionTapped() {
         let vc = JoinSessionViewController()
         vc.delegate = self
-        present(vc, animated: true)
+        let nav = UINavigationController(rootViewController: vc)
+        nav.modalPresentationStyle = .formSheet
+        present(nav, animated: true)
+    }
+    
+    @objc private func createSessionTapped() {
+        let createVC = CreateSessionRequestViewController()
+        createVC.delegate = self
+        let nav = UINavigationController(rootViewController: createVC)
+        nav.modalPresentationStyle = .formSheet
+        present(nav, animated: true)
     }
     
     private func setupEmptyStateView() {
@@ -442,15 +518,40 @@ class SitterSessionsViewController: NNViewController {
 extension SitterSessionsViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         collectionView.deselectItem(at: indexPath, animated: true)
-        
+
         guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
-        
+
         switch item {
         case .session(let session):
-            // Get the nest name from the sitter session
-            Task {
-                if let sitterSession = try? await sessionService.getSitterSession(sessionID: session.id) {
-                    await MainActor.run {
+            // Check if this is a pending session request
+            if session.status == .pendingOwnerSetup {
+                // Handle session request tap - show CreateSessionRequestViewController
+                Task {
+                    do {
+                        if let result = try await sessionService.getSessionRequestInviteCode(sessionID: session.id) {
+                            await MainActor.run {
+                                // Show CreateSessionRequestViewController in viewing mode
+                                let requestVC = CreateSessionRequestViewController()
+                                requestVC.configure(with: session, inviteCode: result.code, nestName: result.nestName)
+
+                                let nav = UINavigationController(rootViewController: requestVC)
+                                present(nav, animated: true)
+                            }
+                        } else {
+                            await MainActor.run {
+                                showToast(text: "Could not find invite code", sentiment: .negative)
+                            }
+                        }
+                    } catch {
+                        await MainActor.run {
+                            showToast(text: "Error: \(error.localizedDescription)", sentiment: .negative)
+                        }
+                    }
+                }
+            } else {
+                // Regular session - show detail view
+                Task { @MainActor in
+                    if let sitterSession = try? await sessionService.getSitterSession(sessionID: session.id) {
                         // Present the detail view modally
                         let detailVC = SitterSessionDetailViewController(session: session, nestName: sitterSession.nestName)
                         detailVC.modalPresentationStyle = .pageSheet
@@ -458,7 +559,7 @@ extension SitterSessionsViewController: UICollectionViewDelegate {
                     }
                 }
             }
-            
+
         case .archivedSession(let archivedSession):
             // Use the archived session initializer
             let detailVC = SitterSessionDetailViewController(archivedSession: archivedSession)
@@ -530,10 +631,33 @@ extension SitterSessionsViewController: CollectionViewLoadable {
 extension SitterSessionsViewController: JoinSessionViewControllerDelegate {
     func joinSessionViewController(didAcceptInvite session: SitterSession) {
         // Reload all sessions to include the newly accepted one
-        Task {
-            await MainActor.run {
-                self.fetchSitterSessions()
-            }
+        Task { @MainActor in
+            self.fetchSitterSessions()
         }
+    }
+}
+
+extension SitterSessionsViewController: CreateSessionRequestViewControllerDelegate {
+    func createSessionRequestViewController(_ controller: CreateSessionRequestViewController, didCreateRequest inviteCode: String, sessionID: String) {
+        // Use InviteDetailViewController to show the code with copy/share functionality
+        let inviteDetailVC = InviteDetailViewController()
+        inviteDetailVC.configure(with: inviteCode, sessionID: sessionID, sitter: nil, isSitterInitiated: true)
+        controller.navigationController?.pushViewController(inviteDetailVC, animated: true)
+    }
+}
+
+extension SitterSessionsViewController: NNSegmentedFilterViewDelegate {
+    func segmentedFilterView(_ filterView: NNSegmentedFilterView, didSelectSegmentAtIndex index: Int) {
+        let newBucket: SessionService.SessionBucket
+
+        switch index {
+        case 0: newBucket = .past
+        case 1: newBucket = .inProgress
+        case 2: newBucket = .upcoming
+        default: newBucket = .inProgress
+        }
+
+        currentBucket = newBucket
+        updateDisplayedSessions()
     }
 } 

--- a/nest-note/Scenes/Sessions/ViewControllers/SessionCalendarViewController.swift
+++ b/nest-note/Scenes/Sessions/ViewControllers/SessionCalendarViewController.swift
@@ -166,6 +166,10 @@ final class SessionCalendarViewController: NNViewController, CollectionViewLoada
         // Add subviews in correct order
         view.addSubview(collectionView)
         view.addSubview(compactCalendarView)
+        view.addSubview(emptyStateView)
+        
+        // Set delegate for empty state view
+        emptyStateView.delegate = self
         
         // Configure footnote text
         let dateFormatter = DateFormatter()
@@ -183,6 +187,10 @@ final class SessionCalendarViewController: NNViewController, CollectionViewLoada
             collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            
+            emptyStateView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            emptyStateView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            emptyStateView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
         ])
         
         // Initial load
@@ -977,5 +985,16 @@ extension SessionCalendarViewController: SessionEventViewControllerDelegate {
         // Notify delegate of updated events
         delegate?.calendarViewController(self, didUpdateEvents: allEvents)
         showToast(text: "Event Updated", sentiment: .positive)
+    }
+}
+
+// MARK: - NNEmptyStateViewDelegate
+extension SessionCalendarViewController: NNEmptyStateViewDelegate {
+    func emptyStateView(_ emptyStateView: NNEmptyStateView, didTapActionWithTag tag: Int) {
+        //
+    }
+    
+    func emptyStateViewDidTapActionButton(_ emptyStateView: NNEmptyStateView) {
+        addEventTapped()
     }
 }

--- a/nest-note/Scenes/Sessions/Views/DateCell.swift
+++ b/nest-note/Scenes/Sessions/Views/DateCell.swift
@@ -18,9 +18,14 @@ final class DateCell: UICollectionViewListCell {
     private var endDate: Date = Date()
     private var isMultiDay: Bool = false
     private var earlyAccessDuration: EarlyAccessDuration = .halfDay
-    
+
     private var isReadOnly: Bool = false
-    
+    private var showEarlyAccess: Bool = true
+
+    // Constraints that need to be updated based on early access visibility
+    private var earlyAccessBottomConstraint: NSLayoutConstraint?
+    private var multiDayBottomConstraint: NSLayoutConstraint?
+
     // Create labels
     let startLabel: UILabel = {
         let label = UILabel()
@@ -118,14 +123,12 @@ final class DateCell: UICollectionViewListCell {
             self?.endTimeTapped()
         }
         multiDayToggle.addTarget(self, action: #selector(multiDayToggleTapped), for: .valueChanged)
-        
+
         // Add to content view
         contentView.addSubview(startLabel)
         contentView.addSubview(startControl)
         contentView.addSubview(endLabel)
         contentView.addSubview(endControl)
-        contentView.addSubview(earlyAccessLabel)
-        contentView.addSubview(earlyAccessButton)
         contentView.addSubview(multiDayLabel)
         contentView.addSubview(multiDayToggle)
         
@@ -134,68 +137,90 @@ final class DateCell: UICollectionViewListCell {
             // Start label constraints
             startLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16),
             startLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
-            
+
             // Start control constraints
             startControl.centerYAnchor.constraint(equalTo: startLabel.centerYAnchor),
             startControl.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
             startControl.leadingAnchor.constraint(greaterThanOrEqualTo: startLabel.trailingAnchor, constant: 16),
-            
+
             // End label constraints
             endLabel.topAnchor.constraint(equalTo: startLabel.bottomAnchor, constant: 24),
             endLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
             endLabel.widthAnchor.constraint(equalTo: startLabel.widthAnchor),
-            
+
             // End control constraints
             endControl.centerYAnchor.constraint(equalTo: endLabel.centerYAnchor),
             endControl.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
             endControl.leadingAnchor.constraint(greaterThanOrEqualTo: endLabel.trailingAnchor, constant: 16),
-            
+
             multiDayLabel.topAnchor.constraint(equalTo: endLabel.bottomAnchor, constant: 24),
             multiDayLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
-            
+
             // Multi-day toggle constraints
             multiDayToggle.centerYAnchor.constraint(equalTo: multiDayLabel.centerYAnchor),
-            multiDayToggle.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
-            
-            // Early access label constraints
-            earlyAccessLabel.topAnchor.constraint(equalTo: multiDayLabel.bottomAnchor, constant: 24),
-            earlyAccessLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
-            earlyAccessLabel.widthAnchor.constraint(equalTo: startLabel.widthAnchor),
-            earlyAccessLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16),
-            
-            // Early access button constraints
-            earlyAccessButton.centerYAnchor.constraint(equalTo: earlyAccessLabel.centerYAnchor),
-            earlyAccessButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
-            earlyAccessButton.leadingAnchor.constraint(greaterThanOrEqualTo: earlyAccessLabel.trailingAnchor, constant: 16)
+            multiDayToggle.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16)
         ])
+
+        // Create conditional bottom constraint for multiDay (used when early access is hidden)
+        multiDayBottomConstraint = multiDayLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16)
     }
     
-    func configure(startDate: Date, endDate: Date, isMultiDay: Bool, isReadOnly: Bool = false) {
+    func configure(startDate: Date, endDate: Date, isMultiDay: Bool, isReadOnly: Bool = false, showEarlyAccess: Bool = false) {
         self.startDate = startDate
         self.endDate = endDate
         self.isMultiDay = isMultiDay
         self.isReadOnly = isReadOnly
-        
+        self.showEarlyAccess = showEarlyAccess
+
         startControl.date = startDate
         endControl.date = endDate
         multiDayToggle.isOn = isMultiDay
         endControl.setStyle(isMultiDay ? .both : .time, animated: false)
-        
+
         startControl.isEnabled = !isReadOnly
         endControl.isEnabled = !isReadOnly
-        earlyAccessButton.isEnabled = !isReadOnly
         multiDayToggle.isEnabled = !isReadOnly
-        
-        // Update early access button appearance for disabled state
-        updateEarlyAccessButtonEnabledState()
-        
+
+        // Setup early access UI if needed
+        if showEarlyAccess {
+            setupEarlyAccessIfNeeded()
+            earlyAccessButton.isEnabled = !isReadOnly
+            updateEarlyAccessButtonEnabledState()
+            updateEarlyAccessButton()
+            multiDayBottomConstraint?.isActive = false
+            earlyAccessBottomConstraint?.isActive = true
+        } else {
+            // No early access - multiDay is the bottom element
+            multiDayBottomConstraint?.isActive = true
+        }
+
         updateDateLabels()
-        updateEarlyAccessButton()
+    }
+
+    private func setupEarlyAccessIfNeeded() {
+        // Only add early access views if not already added
+        guard earlyAccessLabel.superview == nil else { return }
+
+        contentView.addSubview(earlyAccessLabel)
+        contentView.addSubview(earlyAccessButton)
+
+        // Setup early access constraints
+        NSLayoutConstraint.activate([
+            earlyAccessLabel.topAnchor.constraint(equalTo: multiDayLabel.bottomAnchor, constant: 24),
+            earlyAccessLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            earlyAccessLabel.widthAnchor.constraint(equalTo: startLabel.widthAnchor),
+
+            earlyAccessButton.centerYAnchor.constraint(equalTo: earlyAccessLabel.centerYAnchor),
+            earlyAccessButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            earlyAccessButton.leadingAnchor.constraint(greaterThanOrEqualTo: earlyAccessLabel.trailingAnchor, constant: 16)
+        ])
+
+        earlyAccessBottomConstraint = earlyAccessLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -16)
     }
     
     func configure(startDate: Date, endDate: Date, isMultiDay: Bool, earlyAccessDuration: EarlyAccessDuration, isReadOnly: Bool = false) {
         self.earlyAccessDuration = earlyAccessDuration
-        configure(startDate: startDate, endDate: endDate, isMultiDay: isMultiDay, isReadOnly: isReadOnly)
+        configure(startDate: startDate, endDate: endDate, isMultiDay: isMultiDay, isReadOnly: isReadOnly, showEarlyAccess: true)
     }
     
     private func updateDateLabels() {
@@ -241,21 +266,10 @@ final class DateCell: UICollectionViewListCell {
             // Toggling OFF multi-day - allow immediately
             isMultiDay = false
             endControl.setStyle(.time, animated: true)
-            
-            // Sync end date with start date
-            let calendar = Calendar.current
-            let startComponents = calendar.dateComponents([.year, .month, .day], from: startDate)
-            let endTimeComponents = calendar.dateComponents([.hour, .minute], from: endDate)
-            
-            var newComponents = DateComponents()
-            newComponents.year = startComponents.year
-            newComponents.month = startComponents.month
-            newComponents.day = startComponents.day
-            newComponents.hour = endTimeComponents.hour
-            newComponents.minute = endTimeComponents.minute
-            
-            if let newDate = calendar.date(from: newComponents) {
-                updateDates(newEndDate: newDate)
+
+            // Sync end date with start date using centralized utility
+            if let syncedDate = Date.syncEndDateToStartDay(startDate: startDate, endDate: endDate) {
+                updateDates(newEndDate: syncedDate)
             }
         } else {
             // Toggling ON multi-day - let delegate validate first

--- a/nest-note/Scenes/Sessions/Views/NestNameCell.swift
+++ b/nest-note/Scenes/Sessions/Views/NestNameCell.swift
@@ -73,5 +73,18 @@ final class NestNameCell: UICollectionViewCell {
     
     func configure(with nestName: String) {
         nestNameLabel.text = nestName
+        // Style differently if no nest is selected
+        if nestName == "No nest selected" {
+            nestNameLabel.textColor = .tertiaryLabel
+            // Use italic font descriptor for placeholder text
+            if let descriptor = UIFont.preferredFont(forTextStyle: .body).fontDescriptor.withSymbolicTraits(.traitItalic) {
+                nestNameLabel.font = UIFont(descriptor: descriptor, size: 0)
+            } else {
+                nestNameLabel.font = .preferredFont(forTextStyle: .body)
+            }
+        } else {
+            nestNameLabel.textColor = .secondaryLabel
+            nestNameLabel.font = .preferredFont(forTextStyle: .body)
+        }
     }
 }

--- a/nest-note/Scenes/Settings/SettingsViewController.swift
+++ b/nest-note/Scenes/Settings/SettingsViewController.swift
@@ -172,7 +172,7 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
                 section.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 18, bottom: 20, trailing: 18)
                 return section
                 
-            case .myNest, .mySitting, .general, .admin, .experimental, .debug:
+            case .myNest, .mySitting, .general, .admin, .experimental:
                 var config = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
                 config.headerMode = .supplementary
                 let section = NSCollectionLayoutSection.list(using: config, layoutEnvironment: layoutEnvironment)
@@ -215,7 +215,7 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
             var content = cell.defaultContentConfiguration()
             
             switch item {
-            case .myNestItem(let title, let symbolName), .generalItem(let title, let symbolName), .adminItem(let title, let symbolName), .experimentalItem(let title, let symbolName), .debugItem(let title, let symbolName):
+            case .myNestItem(let title, let symbolName), .generalItem(let title, let symbolName), .experimentalItem(let title, let symbolName):
                 content.text = title
                 
                 // Create a symbol configuration with semibold weight
@@ -247,12 +247,92 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
                 } else {
                     cell.alpha = 1.0
                 }
+                
+                cell.contentConfiguration = content
+                cell.accessories = [.disclosureIndicator()]
+                
+            case .adminItem(let title, let symbolName):
+                // Handle "Debug as" separately with segmented control
+                if title == "Debug as" {
+                    let currentStatus = FeatureFlagService.shared.getDebugUserStatus()
+                    let debugAsItem = Item.adminItem(title: "Debug as", symbolName: "person.crop.circle.badge.checkmark")
+                    
+                    // Configure content
+                    content.text = title
+                    let symbolConfiguration = UIImage.SymbolConfiguration(weight: .bold)
+                    let image = UIImage(systemName: symbolName, withConfiguration: symbolConfiguration)?
+                        .withTintColor(NNColors.primary, renderingMode: .alwaysOriginal)
+                    content.image = image
+                    content.imageProperties.tintColor = NNColors.primary
+                    content.imageProperties.maximumSize = CGSize(width: 24, height: 24)
+                    content.imageToTextPadding = 16
+                    content.directionalLayoutMargins.top = 16
+                    content.directionalLayoutMargins.bottom = 16
+                    
+                    // Create segmented control
+                    let segmentedControl = UISegmentedControl(items: ["Free", "Pro"])
+                    segmentedControl.selectedSegmentIndex = currentStatus == "pro" ? 1 : 0
+                    segmentedControl.addAction(UIAction { [weak self] _ in
+                        let newStatus = segmentedControl.selectedSegmentIndex == 1 ? "pro" : "free"
+                        Logger.log(level: .info, category: .general, message: "🔧 DEBUG: Setting debug status to \(newStatus)")
+                        FeatureFlagService.shared.setDebugUserStatus(newStatus)
+                        
+                        // Force reconfigure the cell to ensure state is synced
+                        DispatchQueue.main.async { [weak self] in
+                            guard let self = self else { return }
+                            var snapshot = self.dataSource.snapshot()
+                            if #available(iOS 15.0, *) {
+                                snapshot.reconfigureItems([debugAsItem])
+                            } else {
+                                snapshot.reloadItems([debugAsItem])
+                            }
+                            self.dataSource.apply(snapshot, animatingDifferences: false)
+                        }
+                    }, for: .valueChanged)
+                    
+                    // Create accessory view with proper sizing
+                    let accessoryView = UIView()
+                    accessoryView.addSubview(segmentedControl)
+                    segmentedControl.translatesAutoresizingMaskIntoConstraints = false
+                    
+                    NSLayoutConstraint.activate([
+                        segmentedControl.trailingAnchor.constraint(equalTo: accessoryView.trailingAnchor),
+                        segmentedControl.centerYAnchor.constraint(equalTo: accessoryView.centerYAnchor),
+                        segmentedControl.widthAnchor.constraint(equalToConstant: 100),
+                        segmentedControl.heightAnchor.constraint(equalToConstant: 32)
+                    ])
+                    
+                    // Size the accessory view to fit the segmented control
+                    accessoryView.frame = CGRect(x: 0, y: 0, width: 100, height: 44)
+                    
+                    let accessoryConfig = UICellAccessory.CustomViewConfiguration(
+                        customView: accessoryView,
+                        placement: .trailing(displayed: .always),
+                        reservedLayoutWidth: .custom(100)
+                    )
+                    
+                    cell.contentConfiguration = content
+                    cell.accessories = [.customView(configuration: accessoryConfig)]
+                } else {
+                    // Standard admin items
+                    content.text = title
+                    let symbolConfiguration = UIImage.SymbolConfiguration(weight: .bold)
+                    let image = UIImage(systemName: symbolName, withConfiguration: symbolConfiguration)?
+                        .withTintColor(NNColors.primary, renderingMode: .alwaysOriginal)
+                    content.image = image
+                    content.imageProperties.tintColor = NNColors.primary
+                    content.imageProperties.maximumSize = CGSize(width: 24, height: 24)
+                    content.imageToTextPadding = 16
+                    content.directionalLayoutMargins.top = 16
+                    content.directionalLayoutMargins.bottom = 16
+                    
+                    cell.contentConfiguration = content
+                    cell.accessories = [.disclosureIndicator()]
+                }
+                
             default:
                 break
             }
-            
-            cell.contentConfiguration = content
-            cell.accessories = [.disclosureIndicator()]
         }
         
         let currentNestCellRegistration = UICollectionView.CellRegistration<CurrentNestCell, Item> { cell, indexPath, item in
@@ -269,7 +349,7 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
                 return collectionView.dequeueConfiguredReusableCell(using: accountCellRegistration, for: indexPath, item: item)
             case .currentNest:
                 return collectionView.dequeueConfiguredReusableCell(using: currentNestCellRegistration, for: indexPath, item: item)
-            case .myNest, .mySitting, .general, .admin, .experimental, .debug:
+            case .myNest, .mySitting, .general, .admin, .experimental:
                 return collectionView.dequeueConfiguredReusableCell(using: listCellRegistration, for: indexPath, item: item)
             }
         }
@@ -380,6 +460,7 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
             ("UserDefaults Viewer", "externaldrive.fill"),
             ("View Logs", "text.alignleft"),
             ("Reset App State", "arrow.counterclockwise"),
+            ("Debug as", "person.crop.circle.badge.checkmark"),
         ].map { Item.adminItem(title: $0.0, symbolName: $0.1) }
         snapshot.appendItems(adminItems, toSection: .admin)
 
@@ -429,7 +510,6 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
         case general = "General"
         case admin = "Admin"
         case experimental = "Experimental"
-        case debug = "Debug"
     }
 
     enum Item: Hashable {
@@ -439,7 +519,6 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
         case generalItem(title: String, symbolName: String)
         case adminItem(title: String, symbolName: String)
         case experimentalItem(title: String, symbolName: String)
-        case debugItem(title: String, symbolName: String)
     }
 
     #if DEBUG
@@ -573,6 +652,19 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
         navigationController?.pushViewController(vc, animated: true)
     }
     
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        guard let item = dataSource.itemIdentifier(for: indexPath) else { return true }
+        
+        #if DEBUG
+        // Prevent selection for "Debug as" item since it uses a menu button
+        if case .adminItem(let title, _) = item, title == "Debug as" {
+            return false
+        }
+        #endif
+        
+        return true
+    }
+    
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
         
@@ -612,7 +704,7 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
                         let sessionsVC = NestSessionsViewController()
                         let nav = UINavigationController(rootViewController: sessionsVC)
                         present(nav, animated: true) {
-                            NNTipManager.shared.dismissTip(SettingsTips.sessionsTip)
+//                            NNTipManager.shared.dismissTip(SettingsTips.sessionsTip)
                         }
                     } else {
                         let sessionsVC = SitterSessionsViewController()
@@ -679,10 +771,14 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
         
         #if DEBUG
         case .adminItem(let title, _):
-            handleDebugItemSelection(title)
+            // Skip selection handling for "Debug as" since it uses a menu button
+            if title != "Debug as" {
+                handleDebugItemSelection(title)
+            } else {
+                // Don't deselect - let the menu button handle interaction
+                return
+            }
         case .experimentalItem(let title, _):
-            handleDebugItemSelection(title)
-        case .debugItem(let title, _):
             handleDebugItemSelection(title)
         #endif
             
@@ -1192,8 +1288,25 @@ extension SettingsViewController: RoutineDetailViewControllerDelegate {
             showToast(text: "Routine saved: \(routine.title)")
         }
     }
-    
+
     func routineDetailViewController(didDeleteRoutine routine: RoutineItem) {
         showToast(text: "Routine deleted: \(routine.title)")
+    }
+}
+
+extension SettingsViewController: JoinSessionViewControllerDelegate {
+    func joinSessionViewController(didAcceptInvite session: SitterSession) {
+        // For nest owners redeeming a sitter-initiated request, this won't be called
+        // since they go through the completion flow instead
+        showToast(text: "Session created successfully")
+    }
+}
+
+extension SettingsViewController: CreateSessionRequestViewControllerDelegate {
+    func createSessionRequestViewController(_ controller: CreateSessionRequestViewController, didCreateRequest inviteCode: String, sessionID: String) {
+        // Use InviteDetailViewController to show the code with copy/share functionality
+        let inviteDetailVC = InviteDetailViewController()
+        inviteDetailVC.configure(with: inviteCode, sessionID: sessionID, sitter: nil, isSitterInitiated: true)
+        controller.navigationController?.pushViewController(inviteDetailVC, animated: true)
     }
 }

--- a/nest-note/Scenes/Settings/SettingsViewController.swift
+++ b/nest-note/Scenes/Settings/SettingsViewController.swift
@@ -172,7 +172,7 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
                 section.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 18, bottom: 20, trailing: 18)
                 return section
                 
-            case .myNest, .mySitting, .general, .debug:
+            case .myNest, .mySitting, .general, .admin, .experimental:
                 var config = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
                 config.headerMode = .supplementary
                 let section = NSCollectionLayoutSection.list(using: config, layoutEnvironment: layoutEnvironment)
@@ -215,7 +215,7 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
             var content = cell.defaultContentConfiguration()
             
             switch item {
-            case .myNestItem(let title, let symbolName), .generalItem(let title, let symbolName), .debugItem(let title, let symbolName):
+            case .myNestItem(let title, let symbolName), .generalItem(let title, let symbolName), .experimentalItem(let title, let symbolName):
                 content.text = title
                 
                 // Create a symbol configuration with semibold weight
@@ -247,12 +247,92 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
                 } else {
                     cell.alpha = 1.0
                 }
+                
+                cell.contentConfiguration = content
+                cell.accessories = [.disclosureIndicator()]
+                
+            case .adminItem(let title, let symbolName):
+                // Handle "Debug as" separately with segmented control
+                if title == "Debug as" {
+                    let currentStatus = FeatureFlagService.shared.getDebugUserStatus()
+                    let debugAsItem = Item.adminItem(title: "Debug as", symbolName: "person.crop.circle.badge.checkmark")
+                    
+                    // Configure content
+                    content.text = title
+                    let symbolConfiguration = UIImage.SymbolConfiguration(weight: .bold)
+                    let image = UIImage(systemName: symbolName, withConfiguration: symbolConfiguration)?
+                        .withTintColor(NNColors.primary, renderingMode: .alwaysOriginal)
+                    content.image = image
+                    content.imageProperties.tintColor = NNColors.primary
+                    content.imageProperties.maximumSize = CGSize(width: 24, height: 24)
+                    content.imageToTextPadding = 16
+                    content.directionalLayoutMargins.top = 16
+                    content.directionalLayoutMargins.bottom = 16
+                    
+                    // Create segmented control
+                    let segmentedControl = UISegmentedControl(items: ["Free", "Pro"])
+                    segmentedControl.selectedSegmentIndex = currentStatus == "pro" ? 1 : 0
+                    segmentedControl.addAction(UIAction { [weak self] _ in
+                        let newStatus = segmentedControl.selectedSegmentIndex == 1 ? "pro" : "free"
+                        Logger.log(level: .info, category: .general, message: "🔧 DEBUG: Setting debug status to \(newStatus)")
+                        FeatureFlagService.shared.setDebugUserStatus(newStatus)
+                        
+                        // Force reconfigure the cell to ensure state is synced
+                        DispatchQueue.main.async { [weak self] in
+                            guard let self = self else { return }
+                            var snapshot = self.dataSource.snapshot()
+                            if #available(iOS 15.0, *) {
+                                snapshot.reconfigureItems([debugAsItem])
+                            } else {
+                                snapshot.reloadItems([debugAsItem])
+                            }
+                            self.dataSource.apply(snapshot, animatingDifferences: false)
+                        }
+                    }, for: .valueChanged)
+                    
+                    // Create accessory view with proper sizing
+                    let accessoryView = UIView()
+                    accessoryView.addSubview(segmentedControl)
+                    segmentedControl.translatesAutoresizingMaskIntoConstraints = false
+                    
+                    NSLayoutConstraint.activate([
+                        segmentedControl.trailingAnchor.constraint(equalTo: accessoryView.trailingAnchor),
+                        segmentedControl.centerYAnchor.constraint(equalTo: accessoryView.centerYAnchor),
+                        segmentedControl.widthAnchor.constraint(equalToConstant: 100),
+                        segmentedControl.heightAnchor.constraint(equalToConstant: 32)
+                    ])
+                    
+                    // Size the accessory view to fit the segmented control
+                    accessoryView.frame = CGRect(x: 0, y: 0, width: 100, height: 44)
+                    
+                    let accessoryConfig = UICellAccessory.CustomViewConfiguration(
+                        customView: accessoryView,
+                        placement: .trailing(displayed: .always),
+                        reservedLayoutWidth: .custom(100)
+                    )
+                    
+                    cell.contentConfiguration = content
+                    cell.accessories = [.customView(configuration: accessoryConfig)]
+                } else {
+                    // Standard admin items
+                    content.text = title
+                    let symbolConfiguration = UIImage.SymbolConfiguration(weight: .bold)
+                    let image = UIImage(systemName: symbolName, withConfiguration: symbolConfiguration)?
+                        .withTintColor(NNColors.primary, renderingMode: .alwaysOriginal)
+                    content.image = image
+                    content.imageProperties.tintColor = NNColors.primary
+                    content.imageProperties.maximumSize = CGSize(width: 24, height: 24)
+                    content.imageToTextPadding = 16
+                    content.directionalLayoutMargins.top = 16
+                    content.directionalLayoutMargins.bottom = 16
+                    
+                    cell.contentConfiguration = content
+                    cell.accessories = [.disclosureIndicator()]
+                }
+                
             default:
                 break
             }
-            
-            cell.contentConfiguration = content
-            cell.accessories = [.disclosureIndicator()]
         }
         
         let currentNestCellRegistration = UICollectionView.CellRegistration<CurrentNestCell, Item> { cell, indexPath, item in
@@ -269,7 +349,7 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
                 return collectionView.dequeueConfiguredReusableCell(using: accountCellRegistration, for: indexPath, item: item)
             case .currentNest:
                 return collectionView.dequeueConfiguredReusableCell(using: currentNestCellRegistration, for: indexPath, item: item)
-            case .myNest, .mySitting, .general, .debug:
+            case .myNest, .mySitting, .general, .admin, .experimental:
                 return collectionView.dequeueConfiguredReusableCell(using: listCellRegistration, for: indexPath, item: item)
             }
         }
@@ -365,9 +445,12 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
         snapshot.appendSections([.debug])
         let debugItems = [
             ("Reset App State", "arrow.counterclockwise"),
-            ("View Logs", "text.alignleft"),
-            ("UserDefaults Viewer", "externaldrive.fill"),
-            ("Survey Dashboard", "chart.bar.fill"),
+            ("Debug as", "person.crop.circle.badge.checkmark"),
+        ].map { Item.adminItem(title: $0.0, symbolName: $0.1) }
+        snapshot.appendItems(adminItems, toSection: .admin)
+
+        // Experimental section - testing and development tools
+        let experimentalItems = [
             ("Test Crash", "exclamationmark.triangle"),
             ("Button Playground", "switch.2"),
             ("Onboarding", "sparkles"),
@@ -408,7 +491,8 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
         case myNest = "My Nest"
         case mySitting = "My Sitting"
         case general = "General"
-        case debug = "Debug"
+        case admin = "Admin"
+        case experimental = "Experimental"
     }
 
     enum Item: Hashable {
@@ -416,7 +500,8 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
         case currentNest(name: String, address: String)
         case myNestItem(title: String, symbolName: String)
         case generalItem(title: String, symbolName: String)
-        case debugItem(title: String, symbolName: String)
+        case adminItem(title: String, symbolName: String)
+        case experimentalItem(title: String, symbolName: String)
     }
 
     #if DEBUG
@@ -546,6 +631,19 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
         navigationController?.pushViewController(vc, animated: true)
     }
     
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        guard let item = dataSource.itemIdentifier(for: indexPath) else { return true }
+        
+        #if DEBUG
+        // Prevent selection for "Debug as" item since it uses a menu button
+        if case .adminItem(let title, _) = item, title == "Debug as" {
+            return false
+        }
+        #endif
+        
+        return true
+    }
+    
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
         
@@ -585,7 +683,7 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
                         let sessionsVC = NestSessionsViewController()
                         let nav = UINavigationController(rootViewController: sessionsVC)
                         present(nav, animated: true) {
-                            NNTipManager.shared.dismissTip(SettingsTips.sessionsTip)
+//                            NNTipManager.shared.dismissTip(SettingsTips.sessionsTip)
                         }
                     } else {
                         let sessionsVC = SitterSessionsViewController()
@@ -649,7 +747,15 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
             }
         
         #if DEBUG
-        case .debugItem(let title, _):
+        case .adminItem(let title, _):
+            // Skip selection handling for "Debug as" since it uses a menu button
+            if title != "Debug as" {
+                handleDebugItemSelection(title)
+            } else {
+                // Don't deselect - let the menu button handle interaction
+                return
+            }
+        case .experimentalItem(let title, _):
             handleDebugItemSelection(title)
         #endif
             
@@ -1161,8 +1267,25 @@ extension SettingsViewController: RoutineDetailViewControllerDelegate {
             showToast(text: "Routine saved: \(routine.title)")
         }
     }
-    
+
     func routineDetailViewController(didDeleteRoutine routine: RoutineItem) {
         showToast(text: "Routine deleted: \(routine.title)")
+    }
+}
+
+extension SettingsViewController: JoinSessionViewControllerDelegate {
+    func joinSessionViewController(didAcceptInvite session: SitterSession) {
+        // For nest owners redeeming a sitter-initiated request, this won't be called
+        // since they go through the completion flow instead
+        showToast(text: "Session created successfully")
+    }
+}
+
+extension SettingsViewController: CreateSessionRequestViewControllerDelegate {
+    func createSessionRequestViewController(_ controller: CreateSessionRequestViewController, didCreateRequest inviteCode: String, sessionID: String) {
+        // Use InviteDetailViewController to show the code with copy/share functionality
+        let inviteDetailVC = InviteDetailViewController()
+        inviteDetailVC.configure(with: inviteCode, sessionID: sessionID, sitter: nil, isSitterInitiated: true)
+        controller.navigationController?.pushViewController(inviteDetailVC, animated: true)
     }
 }

--- a/nest-note/Scenes/Sitters/ViewControllers/InviteDetailViewController.swift
+++ b/nest-note/Scenes/Sitters/ViewControllers/InviteDetailViewController.swift
@@ -26,7 +26,8 @@ class InviteDetailViewController: NNViewController {
     }
     private var inviteCode: String?
     private var inviteExists: Bool = false
-    
+    private var isSitterInitiated: Bool = false
+
     // Track original state for change detection
     private var originalSitter: SitterItem?
     
@@ -372,19 +373,20 @@ class InviteDetailViewController: NNViewController {
         }
     }
     
-    func configure(with code: String, sessionID: String, sitter: SitterItem? = nil) {
+    func configure(with code: String, sessionID: String, sitter: SitterItem? = nil, isSitterInitiated: Bool = false) {
         self.inviteCode = code
         self.inviteID = "invite-\(code)"
         self.sessionID = sessionID
         self.selectedSitter = sitter
         self.originalSitter = sitter // Store original state
         self.inviteExists = true
-        
+        self.isSitterInitiated = isSitterInitiated
+
         updateButtonTitle()
         updateButtonState()
         updateActionButtonsVisibility()
-        
-        
+
+
         // Only apply snapshot if view has loaded
         if isViewLoaded {
             applySnapshot()
@@ -455,7 +457,11 @@ class InviteDetailViewController: NNViewController {
             guard let self else { return }
             guard let section = dataSource.sectionIdentifier(for: indexPath.section) else { return }
             if section == .code {
-                footerView.configure(text: "Share this code. Anyone with it can join this session.")
+                if isSitterInitiated {
+                    footerView.configure(text: "Share this code with the Nest Owner. They'll use it to accept your session request and can adjust the dates if needed.")
+                } else {
+                    footerView.configure(text: "Share this code. Anyone with it can join this session.")
+                }
             }
         }
         
@@ -505,25 +511,27 @@ class InviteDetailViewController: NNViewController {
     private func applySnapshot() {
         // Ensure dataSource is initialized before applying snapshot
         guard dataSource != nil else { return }
-        
+
         var snapshot = NSDiffableDataSourceSnapshot<Section, AnyHashable>()
-        
-        // Sitter section
-        snapshot.appendSections([.sitter])
-        if let sitter = selectedSitter {
-            snapshot.appendItems([SitterCellItem(sitter: sitter)], toSection: .sitter)
-        } else {
-            // Show placeholder for "Invite a Sitter"
-            let placeholderSitter = SitterItem(id: "placeholder", name: "Invite a Sitter", email: "")
-            snapshot.appendItems([SitterCellItem(sitter: placeholderSitter)], toSection: .sitter)
+
+        // Sitter section - only show for owner-initiated invites
+        if !isSitterInitiated {
+            snapshot.appendSections([.sitter])
+            if let sitter = selectedSitter {
+                snapshot.appendItems([SitterCellItem(sitter: sitter)], toSection: .sitter)
+            } else {
+                // Show placeholder for "Invite a Sitter"
+                let placeholderSitter = SitterItem(id: "placeholder", name: "Invite a Sitter", email: "")
+                snapshot.appendItems([SitterCellItem(sitter: placeholderSitter)], toSection: .sitter)
+            }
         }
-        
+
         // Code section
         snapshot.appendSections([.code])
         let code = inviteCode ?? "000-000"
         snapshot.appendItems([CodeCellItem(code: code)], toSection: .code)
-        
-        
+
+
         dataSource.apply(snapshot, animatingDifferences: true)
     }
     
@@ -720,11 +728,19 @@ extension InviteDetailViewController {
         
         Task {
             do {
-                // Delete the existing invite
-                try await SessionService.shared.deleteInvite(inviteID: inviteID, sessionID: sessionID)
+                let newInvite: (id: String, code: String)
                 
-                // Create a new invite
-                let newInvite = try await SessionService.shared.createOpenInvite(sessionID: sessionID)
+                if isSitterInitiated {
+                    // For sitter-initiated sessions, use the specialized method
+                    newInvite = try await SessionService.shared.regenerateSitterInitiatedInviteCode(
+                        inviteID: inviteID,
+                        sessionID: sessionID
+                    )
+                } else {
+                    // For owner-initiated sessions, delete and create new invite
+                    try await SessionService.shared.deleteInvite(inviteID: inviteID, sessionID: sessionID)
+                    newInvite = try await SessionService.shared.createOpenInvite(sessionID: sessionID)
+                }
                 
                 await MainActor.run {
                     // Update the invite properties
@@ -795,25 +811,47 @@ extension InviteDetailViewController {
     }
     
     @objc private func deleteButtonTapped() {
+        let title: String
+        let message: String
+        
+        if isSitterInitiated {
+            title = "Cancel Session Request?"
+            message = "This will delete the invite code and cancel your session request. The nest owner will no longer be able to accept it. This action cannot be undone."
+        } else {
+            title = "Delete Invite?"
+            message = "This will remove the sitter's access to this session. This action cannot be undone."
+        }
+        
         let alert = UIAlertController(
-            title: "Delete Invite?",
-            message: "This will remove the sitter's access to this session. This action cannot be undone.",
+            title: title,
+            message: message,
             preferredStyle: .alert
         )
         
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
         
-        alert.addAction(UIAlertAction(title: "Delete", style: .destructive) { [weak self] _ in
+        let deleteTitle = isSitterInitiated ? "Cancel Request" : "Delete"
+        alert.addAction(UIAlertAction(title: deleteTitle, style: .destructive) { [weak self] _ in
             guard let self = self,
                   let inviteID = self.inviteID,
                   let sessionID = self.sessionID else { return }
             
             Task {
                 do {
-                    try await SessionService.shared.deleteInvite(inviteID: inviteID, sessionID: sessionID)
+                    if self.isSitterInitiated {
+                        // For sitter-initiated sessions, use the specialized method
+                        try await SessionService.shared.deleteSitterInitiatedInvite(
+                            inviteID: inviteID,
+                            sessionID: sessionID
+                        )
+                    } else {
+                        // For owner-initiated sessions, use the standard method
+                        try await SessionService.shared.deleteInvite(inviteID: inviteID, sessionID: sessionID)
+                    }
                     
                     await MainActor.run {
-                        self.showToast(text: "Invite deleted")
+                        let message = self.isSitterInitiated ? "Session request cancelled" : "Invite deleted"
+                        self.showToast(text: message)
                         self.delegate?.inviteDetailViewControllerDidDeleteInvite()
                         self.navigationController?.dismiss(animated: true)
                     }

--- a/nest-note/Scenes/Sitters/ViewControllers/JoinSessionViewController.swift
+++ b/nest-note/Scenes/Sitters/ViewControllers/JoinSessionViewController.swift
@@ -28,13 +28,23 @@ class JoinSessionViewController: NNViewController {
     
     private let descriptionLabel: UILabel = {
         let label = UILabel()
-        label.text = "If you've been invited to a session, enter your 6-digit invite code below to be connected to your session."
+        label.text = "Got an invite code? Enter it below to join the session."
         label.font = .bodyL
         label.textColor = .secondaryLabel
         label.textAlignment = .center
         label.numberOfLines = 0
         return label
     }()
+    
+    private func updateMessagingForUserRole() {
+        if ModeManager.shared.isNestOwnerMode {
+            titleLabel.text = "Review Session Request"
+            descriptionLabel.text = "Got an invite code? Enter it below to review the session request."
+        } else {
+            titleLabel.text = "Join a Session"
+            descriptionLabel.text = "Got an invite code? Enter it below to join the session."
+        }
+    }
     
     private let labelStack: UIStackView = {
         let stack = UIStackView()
@@ -165,6 +175,7 @@ class JoinSessionViewController: NNViewController {
         setupInviteCard()
         setupKeyboardObservers()
         setupTextFieldObserver()
+        updateMessagingForUserRole()
     }
     
     override func viewDidLayoutSubviews() {
@@ -350,6 +361,11 @@ class JoinSessionViewController: NNViewController {
             return
         }
         
+        if findSessionButton.titleLabel.text == "Continue Setup" {
+            continueToSetup()
+            return
+        }
+        
         guard let code = codeTextField.textField.text?.replacingOccurrences(of: "-", with: "") else {
             showToast(delay: 0.0, text: "Please enter an invite code", sentiment: .negative)
             return
@@ -371,30 +387,53 @@ class JoinSessionViewController: NNViewController {
 
         Task {
             do {
-                // Only validate the invite, don't accept it yet
-                let (session, invite) = try await SessionService.shared.validateInvite(code: code)
-                self.currentSession = session
-                self.currentInvite = invite
-                
-                try await Task.sleep(for: .seconds(1))
-                await MainActor.run {
-                    // Update UI to show success state
-                    self.titleLabel.text = "Session Found!"
-                    self.descriptionLabel.text = "Review the details of the session below; tapping 'Accept Invite' will add this to your list of upcoming sessions."
-                    
-                    // Configure and show the invite card
-                    self.inviteCardView.configure(with: session, invite: invite)
-                    self.animateInviteCard()
-                    
-                    // Hide the code entry field
-                    UIView.animate(withDuration: 0.3) {
-                        self.codeStack.alpha = 0
+                // First, check if this is a sitter-initiated request
+                // We need to peek at the invite type before deciding which validation to use
+                let inviteID = "invite-\(code)"
+                let inviteRef = SessionService.shared.db.collection("invites").document(inviteID)
+                let inviteDoc = try await inviteRef.getDocument()
+
+                guard inviteDoc.exists,
+                      let invite = try? inviteDoc.data(as: Invite.self) else {
+                    throw SessionError.invalidInviteCode
+                }
+
+                // Route based on invite type
+                if invite.type == .sitterInitiated {
+                    // For sitter-initiated, use the special validation that fetches from sessionRequests
+                    await handleSitterInitiatedInvite(code: code)
+                } else {
+                    // For owner-initiated, use the standard validation
+                    let (session, invite) = try await SessionService.shared.validateInvite(code: code)
+
+                    self.currentSession = session
+                    self.currentInvite = invite
+
+                    try await Task.sleep(for: .seconds(1))
+                    await MainActor.run {
+                        // Update UI to show success state
+                        if ModeManager.shared.isNestOwnerMode {
+                            self.titleLabel.text = "Session Request Found!"
+                            self.descriptionLabel.text = "Review the details of the session request below; tapping 'Accept Invite' will add this to your list of upcoming sessions."
+                        } else {
+                            self.titleLabel.text = "Session Found!"
+                            self.descriptionLabel.text = "Review the details of the session below; tapping 'Accept Invite' will add this to your list of upcoming sessions."
+                        }
+
+                        // Configure and show the invite card
+                        self.inviteCardView.configure(with: session, invite: invite)
+                        self.animateInviteCard()
+
+                        // Hide the code entry field
+                        UIView.animate(withDuration: 0.3) {
+                            self.codeStack.alpha = 0
+                        }
+
+                        // Update button
+                        self.findSessionButton.stopLoading(withSuccess: true)
+                        self.findSessionButton.setTitle("Accept Invite")
+                        self.findSessionButton.isEnabled = true
                     }
-                    
-                    // Update button
-                    self.findSessionButton.stopLoading(withSuccess: true)
-                    self.findSessionButton.setTitle("Accept Invite")
-                    self.findSessionButton.isEnabled = true
                 }
             } catch {
                 showError(error.localizedDescription)
@@ -404,35 +443,84 @@ class JoinSessionViewController: NNViewController {
     
     private func acceptInvite() {
         guard let code = currentInviteCode else { return }
-        
+
         findSessionButton.startLoading()
-        
+
         Task {
             do {
                 let sitterSession = try await SessionService.shared.validateAndAcceptInvite(inviteID: code)
-                
+
                 await MainActor.run {
                     findSessionButton.stopLoading(withSuccess: true)
-                    
+
                     // Show success alert
                     let alert = UIAlertController(
                         title: "Session Joined!",
                         message: "You've successfully joined the session. You can now view all the details in your upcoming sessions.",
                         preferredStyle: .alert
                     )
-                    
+
                     alert.addAction(UIAlertAction(title: "OK", style: .default) { [weak self] _ in
                         // Notify delegate
                         self?.delegate?.joinSessionViewController(didAcceptInvite: sitterSession)
                         self?.dismiss(animated: true)
                     })
-                    
+
                     self.present(alert, animated: true)
                 }
             } catch {
                 showError(error.localizedDescription)
             }
         }
+    }
+
+    private func handleSitterInitiatedInvite(code: String) async {
+        do {
+            let (placeholder, invite) = try await SessionService.shared.validateSitterSessionRequest(code: code)
+
+            self.currentSession = placeholder
+            self.currentInvite = invite
+
+            try await Task.sleep(for: .seconds(1))
+            await MainActor.run {
+                // Update UI to show success state
+                self.titleLabel.text = "Session Request Found!"
+                self.descriptionLabel.text = "Review the details of the session request below; tapping 'Continue Setup' will let you complete the session details."
+
+                // Configure and show the invite card
+                self.inviteCardView.configure(with: placeholder, invite: invite)
+                self.animateInviteCard()
+
+                // Hide the code entry field
+                UIView.animate(withDuration: 0.3) {
+                    self.codeStack.alpha = 0
+                }
+
+                // Update button
+                self.findSessionButton.stopLoading(withSuccess: true)
+                self.findSessionButton.setTitle("Continue Setup")
+                self.findSessionButton.isEnabled = true
+            }
+        } catch {
+            await MainActor.run {
+                self.findSessionButton.stopLoading(withSuccess: false)
+                self.showError(error.localizedDescription)
+            }
+        }
+    }
+    
+    private func continueToSetup() {
+        guard let code = currentInviteCode,
+              let placeholder = currentSession,
+              let invite = currentInvite else { return }
+
+        // Navigate to completion view
+        let completionVC = CompleteSitterSessionRequestViewController(
+            inviteCode: code,
+            placeholderSession: placeholder,
+            invite: invite
+        )
+        navigationController?.pushViewController(completionVC, animated: true)
     }
     
     private func animateInviteCard() {
@@ -446,7 +534,7 @@ class JoinSessionViewController: NNViewController {
         
         // Remove current constraint and add new one
         inviteCardBottomConstraint?.isActive = false
-        inviteCardBottomConstraint = inviteCardView.topAnchor.constraint(equalTo: titleStack.bottomAnchor, constant: 24)
+        inviteCardBottomConstraint = inviteCardView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 0)
         inviteCardBottomConstraint?.isActive = true
         
         // Update glow constraints to follow the card
@@ -480,6 +568,11 @@ class JoinSessionViewController: NNViewController {
     @MainActor
     private func showError(_ message: String) {
         findSessionButton.stopLoading(withSuccess: false)
+        
+        // Reset scan button visibility
+        UIView.animate(withDuration: 0.2) {
+            self.scanButton.isHidden = false
+        }
         
         // Show error alert
         let alert = UIAlertController(
@@ -566,8 +659,13 @@ class JoinSessionViewController: NNViewController {
     
     private func showDebugAnimation() {
         // Update UI to show success state
-        titleLabel.text = "Session Found!"
-        descriptionLabel.text = "Review the details of the session below; tapping 'Accept Invite' will add this to your list of upcoming sessions."
+        if ModeManager.shared.isNestOwnerMode {
+            titleLabel.text = "Session Request Found!"
+            descriptionLabel.text = "Review the details of the session request below; tapping 'Accept Invite' will add this to your list of upcoming sessions."
+        } else {
+            titleLabel.text = "Session Found!"
+            descriptionLabel.text = "Review the details of the session below; tapping 'Accept Invite' will add this to your list of upcoming sessions."
+        }
         
         // Configure the invite card with mock data
         let mockSession = SessionItem(

--- a/nest-note/Scenes/Sitters/ViewControllers/JoinSessionViewController.swift
+++ b/nest-note/Scenes/Sitters/ViewControllers/JoinSessionViewController.swift
@@ -28,13 +28,23 @@ class JoinSessionViewController: NNViewController {
     
     private let descriptionLabel: UILabel = {
         let label = UILabel()
-        label.text = "If you've been invited to a session, enter your 6-digit invite code below to be connected to your session."
+        label.text = "Got an invite code? Enter it below to join the session."
         label.font = .bodyL
         label.textColor = .secondaryLabel
         label.textAlignment = .center
         label.numberOfLines = 0
         return label
     }()
+    
+    private func updateMessagingForUserRole() {
+        if ModeManager.shared.isNestOwnerMode {
+            titleLabel.text = "Review Session Request"
+            descriptionLabel.text = "Got an invite code? Enter it below to review the session request."
+        } else {
+            titleLabel.text = "Join a Session"
+            descriptionLabel.text = "Got an invite code? Enter it below to join the session."
+        }
+    }
     
     private let labelStack: UIStackView = {
         let stack = UIStackView()
@@ -113,6 +123,7 @@ class JoinSessionViewController: NNViewController {
         setupInviteCard()
         setupKeyboardObservers()
         setupTextFieldObserver()
+        updateMessagingForUserRole()
     }
     
     override func addSubviews() {
@@ -254,6 +265,11 @@ class JoinSessionViewController: NNViewController {
             return
         }
         
+        if findSessionButton.titleLabel.text == "Continue Setup" {
+            continueToSetup()
+            return
+        }
+        
         guard let code = codeTextField.textField.text?.replacingOccurrences(of: "-", with: "") else {
             showToast(delay: 0.0, text: "Please enter an invite code", sentiment: .negative)
             return
@@ -275,29 +291,53 @@ class JoinSessionViewController: NNViewController {
 
         Task {
             do {
-                // Only validate the invite, don't accept it yet
-                let (session, invite) = try await SessionService.shared.validateInvite(code: code)
-                self.currentSession = session
-                self.currentInvite = invite
-                
-                try await Task.sleep(for: .seconds(1))
-                await MainActor.run {
-                    // Update UI to show success state
-                    self.titleLabel.text = "Session Found!"
-                    self.descriptionLabel.text = "Review the details of the session below; tapping 'Accept Invite' will add this to your list of upcoming sessions."
-                    
-                    // Configure and show the invite card
-                    self.inviteCardView.configure(with: session, invite: invite)
-                    self.animateInviteCard()
-                    
-                    // Hide the code entry field
-                    UIView.animate(withDuration: 0.3) {
-                        self.codeStack.alpha = 0
+                // First, check if this is a sitter-initiated request
+                // We need to peek at the invite type before deciding which validation to use
+                let inviteID = "invite-\(code)"
+                let inviteRef = SessionService.shared.db.collection("invites").document(inviteID)
+                let inviteDoc = try await inviteRef.getDocument()
+
+                guard inviteDoc.exists,
+                      let invite = try? inviteDoc.data(as: Invite.self) else {
+                    throw SessionError.invalidInviteCode
+                }
+
+                // Route based on invite type
+                if invite.type == .sitterInitiated {
+                    // For sitter-initiated, use the special validation that fetches from sessionRequests
+                    await handleSitterInitiatedInvite(code: code)
+                } else {
+                    // For owner-initiated, use the standard validation
+                    let (session, invite) = try await SessionService.shared.validateInvite(code: code)
+
+                    self.currentSession = session
+                    self.currentInvite = invite
+
+                    try await Task.sleep(for: .seconds(1))
+                    await MainActor.run {
+                        // Update UI to show success state
+                        if ModeManager.shared.isNestOwnerMode {
+                            self.titleLabel.text = "Session Request Found!"
+                            self.descriptionLabel.text = "Review the details of the session request below; tapping 'Accept Invite' will add this to your list of upcoming sessions."
+                        } else {
+                            self.titleLabel.text = "Session Found!"
+                            self.descriptionLabel.text = "Review the details of the session below; tapping 'Accept Invite' will add this to your list of upcoming sessions."
+                        }
+
+                        // Configure and show the invite card
+                        self.inviteCardView.configure(with: session, invite: invite)
+                        self.animateInviteCard()
+
+                        // Hide the code entry field
+                        UIView.animate(withDuration: 0.3) {
+                            self.codeStack.alpha = 0
+                        }
+
+                        // Update button
+                        self.findSessionButton.stopLoading(withSuccess: true)
+                        self.findSessionButton.setTitle("Accept Invite")
+                        self.findSessionButton.isEnabled = true
                     }
-                    
-                    // Update button
-                    self.findSessionButton.stopLoading(withSuccess: true)
-                    self.findSessionButton.setTitle("Accept Invite")
                 }
             } catch {
                 showError(error.localizedDescription)
@@ -307,35 +347,84 @@ class JoinSessionViewController: NNViewController {
     
     private func acceptInvite() {
         guard let code = currentInviteCode else { return }
-        
+
         findSessionButton.startLoading()
-        
+
         Task {
             do {
                 let sitterSession = try await SessionService.shared.validateAndAcceptInvite(inviteID: code)
-                
+
                 await MainActor.run {
                     findSessionButton.stopLoading(withSuccess: true)
-                    
+
                     // Show success alert
                     let alert = UIAlertController(
                         title: "Session Joined!",
                         message: "You've successfully joined the session. You can now view all the details in your upcoming sessions.",
                         preferredStyle: .alert
                     )
-                    
+
                     alert.addAction(UIAlertAction(title: "OK", style: .default) { [weak self] _ in
                         // Notify delegate
                         self?.delegate?.joinSessionViewController(didAcceptInvite: sitterSession)
                         self?.dismiss(animated: true)
                     })
-                    
+
                     self.present(alert, animated: true)
                 }
             } catch {
                 showError(error.localizedDescription)
             }
         }
+    }
+
+    private func handleSitterInitiatedInvite(code: String) async {
+        do {
+            let (placeholder, invite) = try await SessionService.shared.validateSitterSessionRequest(code: code)
+
+            self.currentSession = placeholder
+            self.currentInvite = invite
+
+            try await Task.sleep(for: .seconds(1))
+            await MainActor.run {
+                // Update UI to show success state
+                self.titleLabel.text = "Session Request Found!"
+                self.descriptionLabel.text = "Review the details of the session request below; tapping 'Continue Setup' will let you complete the session details."
+
+                // Configure and show the invite card
+                self.inviteCardView.configure(with: placeholder, invite: invite)
+                self.animateInviteCard()
+
+                // Hide the code entry field
+                UIView.animate(withDuration: 0.3) {
+                    self.codeStack.alpha = 0
+                }
+
+                // Update button
+                self.findSessionButton.stopLoading(withSuccess: true)
+                self.findSessionButton.setTitle("Continue Setup")
+                self.findSessionButton.isEnabled = true
+            }
+        } catch {
+            await MainActor.run {
+                self.findSessionButton.stopLoading(withSuccess: false)
+                self.showError(error.localizedDescription)
+            }
+        }
+    }
+    
+    private func continueToSetup() {
+        guard let code = currentInviteCode,
+              let placeholder = currentSession,
+              let invite = currentInvite else { return }
+
+        // Navigate to completion view
+        let completionVC = CompleteSitterSessionRequestViewController(
+            inviteCode: code,
+            placeholderSession: placeholder,
+            invite: invite
+        )
+        navigationController?.pushViewController(completionVC, animated: true)
     }
     
     private func animateInviteCard() {
@@ -344,7 +433,7 @@ class JoinSessionViewController: NNViewController {
         
         // Remove current constraint and add new one
         inviteCardBottomConstraint?.isActive = false
-        inviteCardBottomConstraint = inviteCardView.topAnchor.constraint(equalTo: titleStack.bottomAnchor, constant: 24)
+        inviteCardBottomConstraint = inviteCardView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 0)
         inviteCardBottomConstraint?.isActive = true
         
         // Animate it up from the bottom with spring effect
@@ -358,6 +447,11 @@ class JoinSessionViewController: NNViewController {
     @MainActor
     private func showError(_ message: String) {
         findSessionButton.stopLoading(withSuccess: false)
+        
+        // Reset scan button visibility
+        UIView.animate(withDuration: 0.2) {
+            self.scanButton.isHidden = false
+        }
         
         // Show error alert
         let alert = UIAlertController(
@@ -429,5 +523,58 @@ class JoinSessionViewController: NNViewController {
         let second = String(digits.dropFirst(3).prefix(3))
         if second.isEmpty { return first }
         return first + "-" + second
+    }
+
+    // MARK: - Debug Mode
+    
+    func enableDebugMode() {
+        isDebugMode = true
+        
+        // Trigger the animation after a short delay
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            self?.showDebugAnimation()
+        }
+    }
+    
+    private func showDebugAnimation() {
+        // Update UI to show success state
+        if ModeManager.shared.isNestOwnerMode {
+            titleLabel.text = "Session Request Found!"
+            descriptionLabel.text = "Review the details of the session request below; tapping 'Accept Invite' will add this to your list of upcoming sessions."
+        } else {
+            titleLabel.text = "Session Found!"
+            descriptionLabel.text = "Review the details of the session below; tapping 'Accept Invite' will add this to your list of upcoming sessions."
+        }
+        
+        // Configure the invite card with mock data
+        let mockSession = SessionItem(
+            id: "debug-123",
+            title: "Evening Babysitting",
+            startDate: Date().addingTimeInterval(86400), // Tomorrow
+            endDate: Date().addingTimeInterval(86400 + 14400), // Tomorrow + 4 hours
+            status: .upcoming,
+            nestID: "nest-456"
+        )
+        
+        let mockInvite = Invite(
+            id: "invite-789",
+            nestID: "nest-456",
+            nestName: "The Johnson Family",
+            sessionID: "debug-123",
+            sitterEmail: "test@example.com",
+            status: .pending,
+            createdAt: Date(),
+            expiresAt: Date().addingTimeInterval(86400 * 7),
+            createdBy: "owner-123"
+        )
+        
+        inviteCardView.configure(with: mockSession, invite: mockInvite)
+        animateInviteCard()
+        
+        // Hide the code entry field
+        UIView.animate(withDuration: 0.3) {
+            self.codeStack.alpha = 0
+            self.buttonStack.alpha = 0
+        }
     }
 }

--- a/nest-note/Scenes/Sitters/Views/SessionInviteCardView.swift
+++ b/nest-note/Scenes/Sitters/Views/SessionInviteCardView.swift
@@ -211,8 +211,24 @@ class SessionInviteCardView: UIView {
     }
     
     func configure(with session: SessionItem, invite: Invite) {
-        // Configure nest name with debug print
-        nestNameLabel.text = invite.nestName
+        // Configure nest name - if owner is viewing a sitter-initiated request with "Unknown Nest",
+        // show the current nest's name instead (since the owner will be accepting it into their nest)
+        if ModeManager.shared.isNestOwnerMode,
+           invite.type == .sitterInitiated,
+           invite.nestName == "Unknown Nest",
+           let currentNestName = NestService.shared.currentNest?.name,
+           !currentNestName.isEmpty {
+            nestNameLabel.text = currentNestName
+        } else {
+            nestNameLabel.text = invite.nestName
+        }
+        
+        // Set badge text based on invite type
+        if invite.type == .sitterInitiated {
+            inviteBadgeLabel.text = "SESSION REQUEST"
+        } else {
+            inviteBadgeLabel.text = "SESSION INVITE"
+        }
         
         // Force layout update
         setNeedsLayout()

--- a/nest-note/Services/FeatureFlagService.swift
+++ b/nest-note/Services/FeatureFlagService.swift
@@ -116,9 +116,20 @@ final class FeatureFlagService {
     }
     
     /// Gets the boolean value for a feature flag
+    /// Checks UserDefaults for local debug overrides first (DEBUG builds only)
     /// - Parameter flag: The feature flag to check
     /// - Returns: The current value of the feature flag
     func isEnabled(_ flag: FeatureFlag) -> Bool {
+        #if DEBUG
+        // Check for local debug override first
+        let overrideKey = "debug_override_\(flag.rawValue)"
+        if UserDefaults.standard.object(forKey: overrideKey) != nil {
+            let overrideValue = UserDefaults.standard.bool(forKey: overrideKey)
+            Logger.log(level: .debug, category: .general, message: "Feature flag '\(flag.rawValue)': \(overrideValue) (LOCAL OVERRIDE)")
+            return overrideValue
+        }
+        #endif
+        
         let value = remoteConfig.configValue(forKey: flag.rawValue).boolValue
         
         #if DEBUG
@@ -126,6 +137,41 @@ final class FeatureFlagService {
         #endif
         
         return value
+    }
+    
+    /// Sets a local debug override for a feature flag (DEBUG builds only)
+    /// This allows overriding RemoteConfig values for testing purposes
+    /// - Parameters:
+    ///   - flag: The feature flag to override
+    ///   - value: The override value
+    func setDebugOverride(_ flag: FeatureFlag, value: Bool) {
+        #if DEBUG
+        let overrideKey = "debug_override_\(flag.rawValue)"
+        UserDefaults.standard.set(value, forKey: overrideKey)
+        Logger.log(level: .info, category: .general, message: "🔧 DEBUG OVERRIDE: Set '\(flag.rawValue)' to \(value)")
+        #endif
+    }
+    
+    /// Removes a local debug override for a feature flag (DEBUG builds only)
+    /// - Parameter flag: The feature flag to remove override for
+    func removeDebugOverride(_ flag: FeatureFlag) {
+        #if DEBUG
+        let overrideKey = "debug_override_\(flag.rawValue)"
+        UserDefaults.standard.removeObject(forKey: overrideKey)
+        Logger.log(level: .info, category: .general, message: "🔧 DEBUG OVERRIDE: Removed override for '\(flag.rawValue)'")
+        #endif
+    }
+    
+    /// Checks if a local debug override exists for a feature flag
+    /// - Parameter flag: The feature flag to check
+    /// - Returns: True if a local override exists, false otherwise
+    func hasDebugOverride(_ flag: FeatureFlag) -> Bool {
+        #if DEBUG
+        let overrideKey = "debug_override_\(flag.rawValue)"
+        return UserDefaults.standard.object(forKey: overrideKey) != nil
+        #else
+        return false
+        #endif
     }
     
     /// Gets the integer value for a remote config key
@@ -236,6 +282,28 @@ final class FeatureFlagService {
     /// - Returns: True if signup logs should be captured, false otherwise
     func shouldCaptureSignupLogs() -> Bool {
         return isEnabled(.captureSignupLogs)
+    }
+    
+    // MARK: - Debug User Status
+    
+    /// Gets the current debug user status (free or pro)
+    /// - Returns: "free" or "pro" based on debugAsProUser flag
+    func getDebugUserStatus() -> String {
+        #if DEBUG
+        return isEnabled(.debugAsProUser) ? "pro" : "free"
+        #else
+        return "free"
+        #endif
+    }
+    
+    /// Sets the debug user status (free or pro)
+    /// - Parameter status: "free" or "pro"
+    func setDebugUserStatus(_ status: String) {
+        #if DEBUG
+        let isPro = status.lowercased() == "pro"
+        setDebugOverride(.debugAsProUser, value: isPro)
+        Logger.log(level: .info, category: .general, message: "🔧 DEBUG USER STATUS: Set to \(status)")
+        #endif
     }
     
     // MARK: - Private Methods

--- a/nest-note/Services/FeatureFlagService.swift
+++ b/nest-note/Services/FeatureFlagService.swift
@@ -9,7 +9,7 @@ import Foundation
 import FirebaseRemoteConfig
 
 final class FeatureFlagService {
-    
+
     // MARK: - Properties
     static let shared = FeatureFlagService()
     private var remoteConfig: RemoteConfig

--- a/nest-note/Services/FeatureFlagService.swift
+++ b/nest-note/Services/FeatureFlagService.swift
@@ -94,9 +94,20 @@ final class FeatureFlagService {
     }
     
     /// Gets the boolean value for a feature flag
+    /// Checks UserDefaults for local debug overrides first (DEBUG builds only)
     /// - Parameter flag: The feature flag to check
     /// - Returns: The current value of the feature flag
     func isEnabled(_ flag: FeatureFlag) -> Bool {
+        #if DEBUG
+        // Check for local debug override first
+        let overrideKey = "debug_override_\(flag.rawValue)"
+        if UserDefaults.standard.object(forKey: overrideKey) != nil {
+            let overrideValue = UserDefaults.standard.bool(forKey: overrideKey)
+            Logger.log(level: .debug, category: .general, message: "Feature flag '\(flag.rawValue)': \(overrideValue) (LOCAL OVERRIDE)")
+            return overrideValue
+        }
+        #endif
+        
         let value = remoteConfig.configValue(forKey: flag.rawValue).boolValue
         
         #if DEBUG
@@ -104,6 +115,41 @@ final class FeatureFlagService {
         #endif
         
         return value
+    }
+    
+    /// Sets a local debug override for a feature flag (DEBUG builds only)
+    /// This allows overriding RemoteConfig values for testing purposes
+    /// - Parameters:
+    ///   - flag: The feature flag to override
+    ///   - value: The override value
+    func setDebugOverride(_ flag: FeatureFlag, value: Bool) {
+        #if DEBUG
+        let overrideKey = "debug_override_\(flag.rawValue)"
+        UserDefaults.standard.set(value, forKey: overrideKey)
+        Logger.log(level: .info, category: .general, message: "🔧 DEBUG OVERRIDE: Set '\(flag.rawValue)' to \(value)")
+        #endif
+    }
+    
+    /// Removes a local debug override for a feature flag (DEBUG builds only)
+    /// - Parameter flag: The feature flag to remove override for
+    func removeDebugOverride(_ flag: FeatureFlag) {
+        #if DEBUG
+        let overrideKey = "debug_override_\(flag.rawValue)"
+        UserDefaults.standard.removeObject(forKey: overrideKey)
+        Logger.log(level: .info, category: .general, message: "🔧 DEBUG OVERRIDE: Removed override for '\(flag.rawValue)'")
+        #endif
+    }
+    
+    /// Checks if a local debug override exists for a feature flag
+    /// - Parameter flag: The feature flag to check
+    /// - Returns: True if a local override exists, false otherwise
+    func hasDebugOverride(_ flag: FeatureFlag) -> Bool {
+        #if DEBUG
+        let overrideKey = "debug_override_\(flag.rawValue)"
+        return UserDefaults.standard.object(forKey: overrideKey) != nil
+        #else
+        return false
+        #endif
     }
     
     /// Gets the integer value for a remote config key
@@ -152,6 +198,28 @@ final class FeatureFlagService {
     /// - Returns: True if signup logs should be captured, false otherwise
     func shouldCaptureSignupLogs() -> Bool {
         return isEnabled(.captureSignupLogs)
+    }
+    
+    // MARK: - Debug User Status
+    
+    /// Gets the current debug user status (free or pro)
+    /// - Returns: "free" or "pro" based on debugAsProUser flag
+    func getDebugUserStatus() -> String {
+        #if DEBUG
+        return isEnabled(.debugAsProUser) ? "pro" : "free"
+        #else
+        return "free"
+        #endif
+    }
+    
+    /// Sets the debug user status (free or pro)
+    /// - Parameter status: "free" or "pro"
+    func setDebugUserStatus(_ status: String) {
+        #if DEBUG
+        let isPro = status.lowercased() == "pro"
+        setDebugOverride(.debugAsProUser, value: isPro)
+        Logger.log(level: .info, category: .general, message: "🔧 DEBUG USER STATUS: Set to \(status)")
+        #endif
     }
     
     // MARK: - Private Methods

--- a/nest-note/Services/OnboardingAnalyticsService.swift
+++ b/nest-note/Services/OnboardingAnalyticsService.swift
@@ -27,6 +27,7 @@ final class OnboardingAnalyticsService {
         var currentStep: String = ""
         var stepsCompleted: [String] = []
         var metadata: [String: String] = [:]
+        var userRole: String? = nil // Track user's selected role
     }
 
     private init() {}
@@ -61,6 +62,14 @@ final class OnboardingAnalyticsService {
         sessionData.stepsCompleted.append(stepId)
 
         Logger.log(level: .info, category: .general, message: "📊 ONBOARDING: Step completed - \(stepId)")
+    }
+
+    /// Records the user's selected role
+    func recordRole(_ role: String) {
+        sessionData.userRole = role
+        sessionData.metadata["role"] = role
+
+        Logger.log(level: .info, category: .general, message: "📊 ONBOARDING: Role selected - \(role)")
     }
 
     /// Records survey response
@@ -181,10 +190,20 @@ final class OnboardingAnalyticsService {
 
     /// Saves onboarding session as SurveyResponse for viewing in existing UI
     private func saveSurveyResponse() {
+        // Determine survey type based on user's role
+        // Default to parentSurvey if role is not set (for backward compatibility)
+        let surveyType: SurveyResponse.SurveyType
+        if let role = sessionData.userRole {
+            // Role is stored as "nester" for nest owners, "sitter" for sitters
+            surveyType = (role == "sitter") ? .sitterSurvey : .parentSurvey
+        } else {
+            surveyType = .parentSurvey
+        }
+
         let surveyResponse = SurveyResponse(
             id: UUID().uuidString,
             timestamp: sessionData.startTime,
-            surveyType: .parentSurvey, // Integrates with existing parent survey system
+            surveyType: surveyType,
             version: "onboarding_\(sessionData.variant)",
             responses: sessionData.surveyResponses,
             metadata: sessionData.metadata

--- a/nest-note/Services/OnboardingAnalyticsService.swift
+++ b/nest-note/Services/OnboardingAnalyticsService.swift
@@ -1,0 +1,265 @@
+//
+//  OnboardingAnalyticsService.swift
+//  nest-note
+//
+//  Created by Claude Code on 11/25/24.
+//
+
+import Foundation
+import FirebaseAnalytics
+
+final class OnboardingAnalyticsService {
+
+    static let shared = OnboardingAnalyticsService()
+
+    // MARK: - Properties
+    private var sessionData = OnboardingSessionData()
+
+    // MARK: - Session Data Model
+    private struct OnboardingSessionData {
+        var variant: String = ""
+        var startTime: Date = Date()
+        var surveyResponses: [SurveyResponse.QuestionResponse] = []
+        var discoveryMethod: String = ""
+        var hasConverted: Bool = false
+        var conversionType: String = ""
+        var productId: String = ""
+        var currentStep: String = ""
+        var stepsCompleted: [String] = []
+        var metadata: [String: String] = [:]
+        var userRole: String? = nil // Track user's selected role
+    }
+
+    private init() {}
+
+    // MARK: - Session Management
+
+    /// Starts a new onboarding session
+    func startSession(variant: String) {
+        sessionData = OnboardingSessionData()
+        sessionData.variant = variant
+        sessionData.startTime = Date()
+
+        // Initialize metadata with onboarding info
+        sessionData.metadata = [
+            "onboarding_variant": variant,
+            "session_type": "parent_onboarding",
+            "start_time": ISO8601DateFormatter().string(from: Date())
+        ]
+
+        Logger.log(level: .info, category: .general, message: "📊 ONBOARDING: Started session - variant: \(variant)")
+
+        // Track session start
+        Analytics.logEvent("parent_onboarding_started", parameters: [
+            "onboarding_variant": variant,
+            "timestamp": ISO8601DateFormatter().string(from: Date())
+        ])
+    }
+
+    /// Records a step completion
+    func recordStepCompleted(_ stepId: String) {
+        sessionData.currentStep = stepId
+        sessionData.stepsCompleted.append(stepId)
+
+        Logger.log(level: .info, category: .general, message: "📊 ONBOARDING: Step completed - \(stepId)")
+    }
+
+    /// Records the user's selected role
+    func recordRole(_ role: String) {
+        sessionData.userRole = role
+        sessionData.metadata["role"] = role
+
+        Logger.log(level: .info, category: .general, message: "📊 ONBOARDING: Role selected - \(role)")
+    }
+
+    /// Records survey response
+    func recordSurveyResponse(questionId: String, answers: [String]) {
+        let questionResponse = SurveyResponse.QuestionResponse(questionId: questionId, answers: answers)
+        sessionData.surveyResponses.append(questionResponse)
+
+        // Update discovery method if this is that question
+        if questionId == "discovery_method", let firstAnswer = answers.first {
+            sessionData.discoveryMethod = firstAnswer
+            sessionData.metadata["discovery_method"] = firstAnswer
+        }
+
+        Logger.log(level: .info, category: .general, message: "📊 ONBOARDING: Survey response - \(questionId): \(answers.joined(separator: ", "))")
+
+        // Track individual question responses for detailed analysis
+        Analytics.logEvent("parent_onboarding_response", parameters: [
+            "onboarding_variant": sessionData.variant,
+            "question_id": questionId,
+            "answers": answers.joined(separator: ","),
+            "answer_count": answers.count
+        ])
+    }
+
+
+    /// Records conversion event
+    func recordConversion(type: String, productId: String? = nil) {
+        sessionData.hasConverted = true
+        sessionData.conversionType = type
+        sessionData.productId = productId ?? ""
+
+        let duration = Date().timeIntervalSince(sessionData.startTime)
+
+        // Update metadata with conversion info
+        sessionData.metadata["converted"] = "true"
+        sessionData.metadata["conversion_type"] = type
+        sessionData.metadata["conversion_duration_seconds"] = String(Int(duration))
+        if let productId = productId {
+            sessionData.metadata["product_id"] = productId
+        }
+
+        Logger.log(level: .info, category: .general, message: "📊 ONBOARDING: Conversion - \(type) after \(Int(duration))s")
+
+        // Track conversion with full context
+        var parameters: [String: Any] = [
+            "onboarding_variant": sessionData.variant,
+            "conversion_type": type,
+            "onboarding_duration_seconds": Int(duration),
+            "steps_completed": sessionData.stepsCompleted.count,
+            "discovery_method": sessionData.discoveryMethod
+        ]
+
+        if let productId = productId {
+            parameters["product_id"] = productId
+        }
+
+        // Add survey responses to conversion event
+        for response in sessionData.surveyResponses {
+            switch response.questionId {
+            case "top_priority":
+                parameters["top_priority"] = response.answers.first ?? ""
+            case "communication_methods":
+                parameters["communication_methods"] = response.answers.joined(separator: ",")
+            case "care_responsibilities":
+                parameters["care_responsibilities"] = response.answers.joined(separator: ",")
+            default:
+                break
+            }
+        }
+
+        Analytics.logEvent("parent_onboarding_conversion", parameters: parameters)
+    }
+
+    /// Records session completion (whether converted or not)
+    func completeSession() {
+        let duration = Date().timeIntervalSince(sessionData.startTime)
+
+        // Update final metadata
+        sessionData.metadata["completed"] = "true"
+        sessionData.metadata["final_step"] = sessionData.currentStep
+        sessionData.metadata["total_duration_seconds"] = String(Int(duration))
+        sessionData.metadata["steps_completed"] = String(sessionData.stepsCompleted.count)
+
+        if !sessionData.hasConverted {
+            sessionData.metadata["converted"] = "false"
+        }
+
+        Logger.log(level: .info, category: .general, message: "📊 ONBOARDING: Session completed - converted: \(sessionData.hasConverted), duration: \(Int(duration))s")
+
+        // Save to existing survey system
+        saveSurveyResponse()
+
+        // Track completion with full session summary
+        var parameters: [String: Any] = [
+            "onboarding_variant": sessionData.variant,
+            "converted": sessionData.hasConverted,
+            "conversion_type": sessionData.conversionType,
+            "onboarding_duration_seconds": Int(duration),
+            "steps_completed": sessionData.stepsCompleted.count,
+            "discovery_method": sessionData.discoveryMethod,
+            "final_step": sessionData.currentStep
+        ]
+
+        // Add key survey insights
+        for response in sessionData.surveyResponses {
+            switch response.questionId {
+            case "top_priority":
+                parameters["top_priority"] = response.answers.first ?? ""
+            case "discovery_method":
+                parameters["discovery_source"] = response.answers.first ?? ""
+            default:
+                break
+            }
+        }
+
+        Analytics.logEvent("parent_onboarding_completed", parameters: parameters)
+    }
+
+    /// Saves onboarding session as SurveyResponse for viewing in existing UI
+    private func saveSurveyResponse() {
+        // Determine survey type based on user's role
+        // Default to parentSurvey if role is not set (for backward compatibility)
+        let surveyType: SurveyResponse.SurveyType
+        if let role = sessionData.userRole {
+            // Role is stored as "nester" for nest owners, "sitter" for sitters
+            surveyType = (role == "sitter") ? .sitterSurvey : .parentSurvey
+        } else {
+            surveyType = .parentSurvey
+        }
+
+        let surveyResponse = SurveyResponse(
+            id: UUID().uuidString,
+            timestamp: sessionData.startTime,
+            surveyType: surveyType,
+            version: "onboarding_\(sessionData.variant)",
+            responses: sessionData.surveyResponses,
+            metadata: sessionData.metadata
+        )
+
+        Task {
+            do {
+                try await SurveyService.shared.submitSurveyResponse(surveyResponse)
+                Logger.log(level: .info, category: .survey, message: "📊 SURVEY: Saved onboarding session as parent survey response - variant: \(sessionData.variant)")
+            } catch {
+                Logger.log(level: .error, category: .survey, message: "📊 SURVEY: Failed to save onboarding response - \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Records drop-off (user exits before completion)
+    func recordDropOff(reason: String = "unknown") {
+        let duration = Date().timeIntervalSince(sessionData.startTime)
+
+        // Update metadata with drop-off info
+        sessionData.metadata["completed"] = "false"
+        sessionData.metadata["drop_off_reason"] = reason
+        sessionData.metadata["drop_off_step"] = sessionData.currentStep
+        sessionData.metadata["total_duration_seconds"] = String(Int(duration))
+
+        Logger.log(level: .info, category: .general, message: "📊 ONBOARDING: Drop-off - step: \(sessionData.currentStep), reason: \(reason)")
+
+        // Save partial session to survey system
+        saveSurveyResponse()
+
+        Analytics.logEvent("parent_onboarding_dropoff", parameters: [
+            "onboarding_variant": sessionData.variant,
+            "last_step": sessionData.currentStep,
+            "steps_completed": sessionData.stepsCompleted.count,
+            "duration_seconds": Int(duration),
+            "drop_reason": reason,
+            "discovery_method": sessionData.discoveryMethod
+        ])
+    }
+
+    // MARK: - Quick Access Methods
+
+    /// Gets current variant for other components to use
+    var currentVariant: String {
+        return sessionData.variant
+    }
+
+    /// Gets formatted session summary for debugging
+    var sessionSummary: String {
+        return """
+        Variant: \(sessionData.variant)
+        Steps: \(sessionData.stepsCompleted.count)
+        Responses: \(sessionData.surveyResponses.count)
+        Discovery: \(sessionData.discoveryMethod)
+        Converted: \(sessionData.hasConverted)
+        Duration: \(Int(Date().timeIntervalSince(sessionData.startTime)))s
+        """
+    }
+}

--- a/nest-note/Services/SessionService.swift
+++ b/nest-note/Services/SessionService.swift
@@ -229,6 +229,9 @@ class SessionService {
                 result.inProgress.append(session)
             case .earlyAccess, .completed, .archived:
                 result.past.append(session)
+            case .pendingOwnerSetup:
+                // Pending requests are not included in normal session lists
+                break
             }
         }
         
@@ -494,6 +497,9 @@ class SessionService {
             // Extended status should only be inferred, not manually set
             throw ServiceError.invalidStatusTransition
         case .archived:
+            throw ServiceError.invalidStatusTransition
+        case .pendingOwnerSetup:
+            // Can't manually transition to pending status
             throw ServiceError.invalidStatusTransition
         }
         
@@ -1287,7 +1293,486 @@ class SessionService {
         Logger.log(level: .info, category: .sessionService, message: "Invite validation successful ✅")
         return (session, invite)
     }
+
+    // MARK: - Sitter-Initiated Session Requests
+
+    /// Creates a session request from a sitter
+    func createSitterSessionRequest(
+        title: String,
+        startDate: Date,
+        endDate: Date,
+        targetNestID: String?,
+        targetNestName: String?
+    ) async throws -> (code: String, sessionID: String) {
+        guard let currentUserID = Auth.auth().currentUser?.uid else {
+            throw SessionError.userNotAuthenticated
+        }
+
+        Logger.log(level: .info, category: .sessionService, message: "Creating sitter session request: \(title)")
+
+        // Generate unique 6-digit invite code
+        let code = try await generateUniqueInviteCode()
+        let inviteID = "invite-\(code)"
+        let sessionID = UUID().uuidString
+
+        // Get current user info for the assigned sitter
+        let currentUser = UserService.shared.currentUser
+        let sitterName = currentUser?.personalInfo.name ?? ""
+        let sitterEmail = currentUser?.personalInfo.email ?? Auth.auth().currentUser?.email ?? ""
+
+        // Create placeholder session item with sitter info pre-populated
+        let calendar = Calendar.current
+        let sessionRequest = SessionItem(
+            id: sessionID,
+            title: title,
+            startDate: startDate,
+            endDate: endDate,
+            isMultiDay: calendar.startOfDay(for: startDate) != calendar.startOfDay(for: endDate),
+            events: [],
+            status: .pendingOwnerSetup,
+            assignedSitter: AssignedSitter(
+                id: currentUserID,
+                name: sitterName,
+                email: sitterEmail,
+                userID: currentUserID,
+                inviteStatus: .invited,  // Use .invited instead of .pending
+                inviteID: inviteID
+            ),
+            nestID: targetNestID ?? "",  // Use empty string if no nest selected
+            ownerID: nil,  // No owner yet
+            earlyAccessDuration: .halfDay,  // Default
+            earlyAccessEndDate: nil,
+            entryIds: nil,
+            ownerReviewedAt: nil
+        )
+
+        // Store in sitter's sessionRequests collection
+        let requestRef = db.collection("users").document(currentUserID)
+            .collection("sessionRequests").document(sessionID)
+
+        let encoder = Firestore.Encoder()
+        let encodedRequest = try encoder.encode(sessionRequest)
+        try await requestRef.setData(encodedRequest)
+
+        // Create invite
+        let invite = Invite(
+            id: inviteID,
+            nestID: targetNestID ?? "",  // Use empty string if no nest selected
+            nestName: targetNestName ?? "Unknown Nest",  // Use placeholder if no nest selected
+            sessionID: sessionID,
+            sitterEmail: nil,  // Open invite
+            status: .pending,
+            expiresAt: endDate,
+            createdBy: currentUserID,
+            inviteType: .sitterInitiated  // Mark as sitter-initiated
+        )
+
+        let inviteRef = db.collection("invites").document(inviteID)
+        let encodedInvite = try encoder.encode(invite)
+        try await inviteRef.setData(encodedInvite)
+
+        Logger.log(level: .info, category: .sessionService, message: "Sitter session request created with code: \(code) ✅")
+
+        return (code: code, sessionID: sessionID)
+    }
+
+    /// Validates a sitter-initiated session request
+    func validateSitterSessionRequest(code: String) async throws -> (SessionItem, Invite) {
+        Logger.log(level: .info, category: .sessionService, message: "Validating sitter session request: \(code)")
+
+        let inviteID = "invite-\(code)"
+        let inviteRef = db.collection("invites").document(inviteID)
+
+        // Get the invite document
+        let inviteDoc = try await inviteRef.getDocument()
+        guard inviteDoc.exists,
+              let invite = try? inviteDoc.data(as: Invite.self) else {
+            throw SessionError.invalidInviteCode
+        }
+
+        // Verify it's a sitter-initiated invite
+        guard invite.type == .sitterInitiated else {
+            throw SessionError.invalidInviteCode
+        }
+
+        // Validate expiration
+        if invite.expiresAt < Date() {
+            throw SessionError.inviteExpired
+        }
+
+        // Validate status
+        guard invite.status == .pending else {
+            throw SessionError.inviteAlreadyUsed
+        }
+
+        // Get the placeholder session from sitter's requests
+        let requestRef = db.collection("users").document(invite.createdBy)
+            .collection("sessionRequests").document(invite.sessionID)
+
+        let requestDoc = try await requestRef.getDocument()
+        guard requestDoc.exists,
+              let placeholder = try? requestDoc.data(as: SessionItem.self) else {
+            throw SessionError.sessionNotFound
+        }
+
+        Logger.log(level: .info, category: .sessionService, message: "Sitter session request validation successful ✅")
+        return (placeholder, invite)
+    }
     
+    /// Regenerates an invite code for a sitter-initiated session request
+    func regenerateSitterInitiatedInviteCode(inviteID: String, sessionID: String) async throws -> (id: String, code: String) {
+        guard let currentUserID = Auth.auth().currentUser?.uid else {
+            throw SessionError.userNotAuthenticated
+        }
+        
+        Logger.log(level: .info, category: .sessionService, message: "Regenerating invite code for sitter-initiated session: \(sessionID)")
+        
+        // Get the current invite to extract nest info
+        let inviteRef = db.collection("invites").document(inviteID)
+        let inviteDoc = try await inviteRef.getDocument()
+        guard inviteDoc.exists,
+              let oldInvite = try? inviteDoc.data(as: Invite.self) else {
+            throw SessionError.invalidInviteCode
+        }
+        
+        // Verify it's a sitter-initiated invite
+        guard oldInvite.type == .sitterInitiated else {
+            throw SessionError.invalidInviteCode
+        }
+        
+        // Get the session request to get expiration time
+        let requestRef = db.collection("users").document(currentUserID)
+            .collection("sessionRequests").document(sessionID)
+        
+        let requestDoc = try await requestRef.getDocument()
+        guard requestDoc.exists,
+              let sessionRequest = try? requestDoc.data(as: SessionItem.self) else {
+            throw SessionError.sessionNotFound
+        }
+        
+        // Generate new unique code
+        let newCode = try await generateUniqueInviteCode()
+        let newInviteID = "invite-\(newCode)"
+        
+        // Create new invite with sitter-initiated type
+        let newInvite = Invite(
+            id: newInviteID,
+            nestID: oldInvite.nestID,
+            nestName: oldInvite.nestName,
+            sessionID: sessionID,
+            sitterEmail: nil,  // Open invite
+            status: .pending,
+            expiresAt: sessionRequest.endDate,
+            createdBy: currentUserID,
+            inviteType: .sitterInitiated
+        )
+        
+        // Update assigned sitter with new invite ID
+        // If assignedSitter doesn't exist, create one (shouldn't happen but handle edge case)
+        var updatedAssignedSitter: AssignedSitter
+        if var existingSitter = sessionRequest.assignedSitter {
+            existingSitter.inviteID = newInviteID
+            updatedAssignedSitter = existingSitter
+        } else {
+            // Create new assigned sitter if one doesn't exist
+            let currentUser = UserService.shared.currentUser
+            updatedAssignedSitter = AssignedSitter(
+                id: currentUserID,
+                name: currentUser?.personalInfo.name ?? "",
+                email: currentUser?.personalInfo.email ?? Auth.auth().currentUser?.email ?? "",
+                userID: currentUserID,
+                inviteStatus: .invited,
+                inviteID: newInviteID
+            )
+        }
+        
+        let encoder = Firestore.Encoder()
+        let encodedInvite = try encoder.encode(newInvite)
+        let encodedSitter = try encoder.encode(updatedAssignedSitter)
+        
+        // Delete old invite and create new one, update sessionRequest atomically
+        try await db.runTransaction { transaction, errorPointer in
+            // Delete old invite
+            transaction.deleteDocument(inviteRef)
+            
+            // Create new invite
+            transaction.setData(encodedInvite, forDocument: self.db.collection("invites").document(newInviteID))
+            
+            // Update sessionRequest with new invite ID
+            transaction.updateData(["assignedSitter": encodedSitter], forDocument: requestRef)
+            
+            return nil
+        }
+        
+        Logger.log(level: .info, category: .sessionService, message: "Sitter-initiated invite code regenerated successfully ✅")
+        return (id: newInviteID, code: newCode)
+    }
+    
+    /// Deletes an invite for a sitter-initiated session request
+    /// Note: This also cancels the session request since without an invite, the request cannot be accepted
+    func deleteSitterInitiatedInvite(inviteID: String, sessionID: String) async throws {
+        guard let currentUserID = Auth.auth().currentUser?.uid else {
+            throw SessionError.userNotAuthenticated
+        }
+        
+        Logger.log(level: .info, category: .sessionService, message: "Deleting sitter-initiated invite and cancelling session request: \(inviteID)")
+        
+        // Get the invite to verify it's sitter-initiated
+        let inviteRef = db.collection("invites").document(inviteID)
+        let inviteDoc = try await inviteRef.getDocument()
+        guard inviteDoc.exists,
+              let invite = try? inviteDoc.data(as: Invite.self) else {
+            throw SessionError.invalidInviteCode
+        }
+        
+        // Verify it's a sitter-initiated invite
+        guard invite.type == .sitterInitiated else {
+            throw SessionError.invalidInviteCode
+        }
+        
+        // Get reference to sessionRequest
+        let requestRef = db.collection("users").document(currentUserID)
+            .collection("sessionRequests").document(sessionID)
+        
+        // Verify session request exists
+        let requestDoc = try await requestRef.getDocument()
+        guard requestDoc.exists else {
+            // Session request doesn't exist - just delete the invite
+            try await inviteRef.delete()
+            Logger.log(level: .info, category: .sessionService, message: "Sitter-initiated invite deleted (no session request) ✅")
+            return
+        }
+        
+        // Delete invite, cancel it, and delete session request atomically
+        // This ensures consistency: if the invite is deleted, the request is cancelled
+        try await db.runTransaction { transaction, errorPointer in
+            // Delete the invite document
+            transaction.deleteDocument(inviteRef)
+            
+            // Delete the session request (cancelling it)
+            transaction.deleteDocument(requestRef)
+            
+            return nil
+        }
+        
+        Logger.log(level: .info, category: .sessionService, message: "Sitter-initiated invite deleted and session request cancelled ✅")
+    }
+
+    /// Accepts a sitter-initiated session request and creates the actual session
+    func acceptSitterSessionRequest(
+        inviteCode: String,
+        completedSession: SessionItem,
+        sitterInfo: (name: String, email: String, userID: String)
+    ) async throws {
+        guard let currentUserID = Auth.auth().currentUser?.uid else {
+            throw SessionError.userNotAuthenticated
+        }
+
+        Logger.log(level: .info, category: .sessionService, message: "Accepting sitter session request: \(inviteCode)")
+
+        let inviteID = "invite-\(inviteCode)"
+
+        // Validate the request first
+        let (placeholder, invite) = try await validateSitterSessionRequest(code: inviteCode)
+
+        // Create final session with owner set and status changed to upcoming
+        var finalSession = completedSession
+        finalSession.status = .upcoming
+        finalSession.ownerID = currentUserID
+        
+        // Ensure nestID is set - critical for creating the session document
+        // Priority: 1) session's nestID, 2) invite's nestID, 3) current nest from NestService
+        // Also capture nest name early to avoid extra reads
+        var cachedNestName: String? = nil
+        if finalSession.nestID.isEmpty {
+            if !invite.nestID.isEmpty {
+                finalSession.nestID = invite.nestID
+            } else if let currentNest = NestService.shared.currentNest {
+                finalSession.nestID = currentNest.id
+                cachedNestName = currentNest.name // Capture name when we have it
+            } else {
+                Logger.log(level: .error, category: .sessionService, message: "Cannot accept request: nestID is empty and no current nest available")
+                throw SessionError.noCurrentNest
+            }
+        }
+        
+        // Validate that nestID is not empty before proceeding
+        guard !finalSession.nestID.isEmpty else {
+            Logger.log(level: .error, category: .sessionService, message: "Cannot accept request: nestID is still empty after fallback attempts")
+            throw SessionError.noCurrentNest
+        }
+        
+        // Validate that sitter userID is not empty (required for document path)
+        guard !sitterInfo.userID.isEmpty else {
+            Logger.log(level: .error, category: .sessionService, message: "Cannot accept request: sitter userID is empty")
+            throw SessionError.userNotAuthenticated
+        }
+        
+        // Validate that session ID is not empty
+        guard !finalSession.id.isEmpty else {
+            Logger.log(level: .error, category: .sessionService, message: "Cannot accept request: session ID is empty")
+            throw SessionError.sessionNotFound
+        }
+
+        // Set assigned sitter info
+        finalSession.assignedSitter = AssignedSitter(
+            id: UUID().uuidString,
+            name: sitterInfo.name,
+            email: sitterInfo.email,
+            userID: sitterInfo.userID,
+            inviteStatus: .accepted,
+            inviteID: inviteID
+        )
+
+        // Fetch the actual nest name from the nest document
+        // This ensures we use the correct nest name even if the invite had "Unknown Nest"
+        let actualNestName: String
+        // First, use cached name if we captured it above (most common case)
+        if let cachedName = cachedNestName {
+            actualNestName = cachedName
+            Logger.log(level: .info, category: .sessionService, message: "Using cached nest name: \(cachedName) for nestID: \(finalSession.nestID)")
+        } else if let currentNest = NestService.shared.currentNest, currentNest.id == finalSession.nestID {
+            // Fallback: check NestService cache (in case nestID was set from invite but nest is still cached)
+            actualNestName = currentNest.name
+            Logger.log(level: .info, category: .sessionService, message: "Using current nest name: \(currentNest.name) for nestID: \(finalSession.nestID)")
+        } else {
+            // Last resort: Fetch from Firestore if not in cache
+            do {
+                let nestRef = db.collection("nests").document(finalSession.nestID)
+                let nestDoc = try await nestRef.getDocument()
+                if nestDoc.exists, let nest = try? nestDoc.data(as: NestItem.self) {
+                    actualNestName = nest.name
+                    Logger.log(level: .info, category: .sessionService, message: "Fetched actual nest name: \(nest.name) for nestID: \(finalSession.nestID)")
+                } else {
+                    // Fallback to invite nest name if nest document doesn't exist or can't be decoded
+                    actualNestName = invite.nestName
+                    Logger.log(level: .info, category: .sessionService, message: "Could not fetch nest document, using invite nest name: \(invite.nestName)")
+                }
+            } catch {
+                // Fallback to invite nest name if fetch fails
+                actualNestName = invite.nestName
+                Logger.log(level: .info, category: .sessionService, message: "Error fetching nest name, using invite nest name: \(invite.nestName), error: \(error.localizedDescription)")
+            }
+        }
+
+        // Create SitterSession for the sitter
+        let sitterSession = SitterSession(
+            id: finalSession.id,
+            nestID: finalSession.nestID,
+            nestName: actualNestName,
+            inviteAcceptedAt: Date(),
+            readyToArchive: nil,
+            parentSessionCompletedDate: nil,
+            parentSessionArchivedDate: nil,
+            reviewedAt: nil
+        )
+
+        let encoder = Firestore.Encoder()
+
+        // Use transaction to ensure atomicity
+        try await db.runTransaction { transaction, errorPointer in
+            // 1. Create session in nest
+            let sessionRef = self.db.collection("nests").document(finalSession.nestID)
+                .collection("sessions").document(finalSession.id)
+            let encodedSession = try! encoder.encode(finalSession)
+            transaction.setData(encodedSession, forDocument: sessionRef)
+
+            // 2. Create sitterSession for sitter
+            let sitterSessionRef = self.db.collection("users").document(sitterInfo.userID)
+                .collection("sitterSessions").document(finalSession.id)
+            let encodedSitterSession = try! encoder.encode(sitterSession)
+            transaction.setData(encodedSitterSession, forDocument: sitterSessionRef)
+
+            // 3. Update invite status
+            let inviteRef = self.db.collection("invites").document(inviteID)
+            transaction.updateData(["status": InviteStatus.accepted.rawValue], forDocument: inviteRef)
+
+            // 4. Delete placeholder from sitter's requests
+            let requestRef = self.db.collection("users").document(invite.createdBy)
+                .collection("sessionRequests").document(placeholder.id)
+            transaction.deleteDocument(requestRef)
+
+            return nil
+        }
+
+        // Add to local cache
+        sessions.append(finalSession)
+
+        Logger.log(level: .info, category: .sessionService, message: "Sitter session request accepted successfully ✅")
+
+        // Track event
+        Tracker.shared.track(.sessionCreated)
+    }
+
+    /// Fetches all session requests created by a sitter
+    func fetchSitterSessionRequests(userID: String) async throws -> [SessionItem] {
+        Logger.log(level: .info, category: .sessionService, message: "Fetching session requests for sitter: \(userID)")
+
+        let requestsRef = db.collection("users").document(userID)
+            .collection("sessionRequests")
+
+        let snapshot = try await requestsRef.getDocuments()
+        let requests = try snapshot.documents.compactMap { try $0.data(as: SessionItem.self) }
+
+        Logger.log(level: .info, category: .sessionService, message: "Fetched \(requests.count) session requests ✅")
+        return requests
+    }
+
+    /// Cancels a sitter session request
+    func cancelSitterSessionRequest(sessionID: String) async throws {
+        guard let currentUserID = Auth.auth().currentUser?.uid else {
+            throw SessionError.userNotAuthenticated
+        }
+
+        Logger.log(level: .info, category: .sessionService, message: "Cancelling session request: \(sessionID)")
+
+        // Delete from sessionRequests
+        let requestRef = db.collection("users").document(currentUserID)
+            .collection("sessionRequests").document(sessionID)
+        try await requestRef.delete()
+
+        // Find and cancel associated invite
+        let invitesRef = db.collection("invites")
+            .whereField("sessionID", isEqualTo: sessionID)
+            .whereField("createdBy", isEqualTo: currentUserID)
+            .whereField("inviteType", isEqualTo: InviteType.sitterInitiated.rawValue)
+
+        let inviteSnapshot = try await invitesRef.getDocuments()
+        for doc in inviteSnapshot.documents {
+            try await doc.reference.updateData(["status": InviteStatus.cancelled.rawValue])
+        }
+
+        Logger.log(level: .info, category: .sessionService, message: "Session request cancelled ✅")
+    }
+
+    /// Gets the invite code and nest name for a sitter-initiated session request
+    func getSessionRequestInviteCode(sessionID: String) async throws -> (code: String, nestName: String)? {
+        guard let currentUserID = Auth.auth().currentUser?.uid else {
+            throw SessionError.userNotAuthenticated
+        }
+
+        Logger.log(level: .info, category: .sessionService, message: "Fetching invite code for session request: \(sessionID)")
+
+        let invitesRef = db.collection("invites")
+            .whereField("sessionID", isEqualTo: sessionID)
+            .whereField("createdBy", isEqualTo: currentUserID)
+            .whereField("inviteType", isEqualTo: InviteType.sitterInitiated.rawValue)
+            .whereField("status", isEqualTo: InviteStatus.pending.rawValue)
+
+        let snapshot = try await invitesRef.getDocuments()
+        guard let inviteDoc = snapshot.documents.first,
+              let invite = try? inviteDoc.data(as: Invite.self) else {
+            Logger.log(level: .info, category: .sessionService, message: "No invite found for session request")
+            return nil
+        }
+
+        // Extract code from invite ID (format: "invite-123456")
+        let code = invite.id.replacingOccurrences(of: "invite-", with: "")
+        Logger.log(level: .info, category: .sessionService, message: "Found invite code: \(code)")
+
+        return (code: code, nestName: invite.nestName)
+    }
+
     // MARK: - Sitter Sessions
     
     /// Fetches a specific sitter session by ID
@@ -1348,6 +1833,24 @@ class SessionService {
         return collection
     }
     
+    /// Fetches pending session requests created by a sitter
+//    func fetchSitterSessionRequests(userID: String) async throws -> [SessionItem] {
+//        Logger.log(level: .info, category: .sessionService, message: "Fetching sitter session requests for user: \(userID)")
+//
+//        let sessionRequestsRef = db.collection("users").document(userID)
+//            .collection("sessionRequests")
+//
+//        let snapshot = try await sessionRequestsRef.getDocuments()
+//        let requests = try snapshot.documents.compactMap { try $0.data(as: SessionItem.self) }
+//
+//        // Filter for only pending requests (shouldn't be any others, but safety check)
+//        let pendingRequests = requests.filter { $0.status == .pendingOwnerSetup }
+//
+//        Logger.log(level: .info, category: .sessionService, message: "Fetched \(pendingRequests.count) session requests ✅")
+//
+//        return pendingRequests.sorted { $0.startDate < $1.startDate }
+//    }
+
     /// Deletes a sitter session from a user's collection
     func deleteSitterSession(sessionID: String) async throws {
         guard let userID = Auth.auth().currentUser?.uid else {
@@ -1557,34 +2060,48 @@ enum InviteStatus: String, Codable {
     case rejected
 }
 
+enum InviteType: String, Codable {
+    case ownerInitiated
+    case sitterInitiated
+}
+
 // MARK: - Invite Model
 struct Invite: Codable, Identifiable {
     let id: String  // Format: "invite-123456"
     let nestID: String
-    let nestName: String  // Add nestName field
+    let nestName: String
     let sessionID: String
     let sitterEmail: String?
     let status: InviteStatus
     let createdAt: Date
     let expiresAt: Date
     let createdBy: String
-    
+
+    // OPTIONAL for backward compatibility - existing documents won't have this field
+    let inviteType: InviteType?
+
+    // Computed property for safe access with fallback to ownerInitiated
+    var type: InviteType {
+        return inviteType ?? .ownerInitiated
+    }
+
     // Helper computed property for getting the raw code
     var rawCode: String {
         let parts = id.split(separator: "-")
         return parts.count > 1 ? String(parts[1]) : ""
     }
-    
+
     init(
         id: String,
         nestID: String,
-        nestName: String,  // Add nestName parameter
+        nestName: String,
         sessionID: String,
         sitterEmail: String?,
         status: InviteStatus,
         createdAt: Date = Date(),
         expiresAt: Date? = nil,
-        createdBy: String
+        createdBy: String,
+        inviteType: InviteType = .ownerInitiated
     ) {
         self.id = id
         self.nestID = nestID
@@ -1595,6 +2112,7 @@ struct Invite: Codable, Identifiable {
         self.createdAt = createdAt
         self.expiresAt = expiresAt ?? createdAt.addingTimeInterval(48 * 60 * 60) // Fallback: 48 hours validity (invites should use session end time)
         self.createdBy = createdBy
+        self.inviteType = inviteType
     }
 }
 

--- a/nest-note/SupportingFiles/SceneDelegate.swift
+++ b/nest-note/SupportingFiles/SceneDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import FirebaseAuth
+import FirebaseFirestore
 import UserNotifications
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -157,15 +158,58 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             return
         }
         
-        // Check if user is in nest owner mode and needs to switch to sitter mode
-        if ModeManager.shared.isNestOwnerMode {
-            DispatchQueue.main.async {
-                self.showModeSwitchAlert(for: code)
+        // Check invite type to determine if mode switch is needed
+        Task {
+            await checkInviteTypeAndRoute(code: code)
+        }
+    }
+    
+    private func checkInviteTypeAndRoute(code: String) async {
+        do {
+            // Fetch the invite to check its type
+            let inviteID = "invite-\(code)"
+            let inviteRef = SessionService.shared.db.collection("invites").document(inviteID)
+            let inviteDoc = try await inviteRef.getDocument()
+            
+            // If invite doesn't exist, proceed with default behavior (show mode switch for owners)
+            guard inviteDoc.exists,
+                  let invite = try? inviteDoc.data(as: Invite.self) else {
+                await MainActor.run {
+                    // Invite not found - use default behavior
+                    if ModeManager.shared.isNestOwnerMode {
+                        self.showModeSwitchAlert(for: code)
+                    } else {
+                        self.presentJoinSessionViewController(with: code)
+                    }
+                }
+                return
             }
-        } else {
-            // User is already in sitter mode, proceed directly
-            DispatchQueue.main.async {
-                self.presentJoinSessionViewController(with: code)
+            
+            // Route based on invite type and user mode
+            await MainActor.run {
+                if ModeManager.shared.isNestOwnerMode {
+                    // Owner scanning an invite
+                    if invite.type == .sitterInitiated {
+                        // Sitter-initiated invite: owner can accept without switching modes
+                        self.presentJoinSessionViewController(with: code)
+                    } else {
+                        // Owner-initiated invite: owner needs to switch to sitter mode
+                        self.showModeSwitchAlert(for: code)
+                    }
+                } else {
+                    // User is already in sitter mode, proceed directly
+                    self.presentJoinSessionViewController(with: code)
+                }
+            }
+        } catch {
+            Logger.log(level: .error, category: .launcher, message: "Error checking invite type: \(error.localizedDescription)")
+            // On error, fall back to default behavior
+            await MainActor.run {
+                if ModeManager.shared.isNestOwnerMode {
+                    self.showModeSwitchAlert(for: code)
+                } else {
+                    self.presentJoinSessionViewController(with: code)
+                }
             }
         }
     }

--- a/nest-note/SupportingFiles/SceneDelegate.swift
+++ b/nest-note/SupportingFiles/SceneDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import FirebaseAuth
+import FirebaseFirestore
 import UserNotifications
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -160,15 +161,58 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             return
         }
         
-        // Check if user is in nest owner mode and needs to switch to sitter mode
-        if ModeManager.shared.isNestOwnerMode {
-            DispatchQueue.main.async {
-                self.showModeSwitchAlert(for: code)
+        // Check invite type to determine if mode switch is needed
+        Task {
+            await checkInviteTypeAndRoute(code: code)
+        }
+    }
+    
+    private func checkInviteTypeAndRoute(code: String) async {
+        do {
+            // Fetch the invite to check its type
+            let inviteID = "invite-\(code)"
+            let inviteRef = SessionService.shared.db.collection("invites").document(inviteID)
+            let inviteDoc = try await inviteRef.getDocument()
+            
+            // If invite doesn't exist, proceed with default behavior (show mode switch for owners)
+            guard inviteDoc.exists,
+                  let invite = try? inviteDoc.data(as: Invite.self) else {
+                await MainActor.run {
+                    // Invite not found - use default behavior
+                    if ModeManager.shared.isNestOwnerMode {
+                        self.showModeSwitchAlert(for: code)
+                    } else {
+                        self.presentJoinSessionViewController(with: code)
+                    }
+                }
+                return
             }
-        } else {
-            // User is already in sitter mode, proceed directly
-            DispatchQueue.main.async {
-                self.presentJoinSessionViewController(with: code)
+            
+            // Route based on invite type and user mode
+            await MainActor.run {
+                if ModeManager.shared.isNestOwnerMode {
+                    // Owner scanning an invite
+                    if invite.type == .sitterInitiated {
+                        // Sitter-initiated invite: owner can accept without switching modes
+                        self.presentJoinSessionViewController(with: code)
+                    } else {
+                        // Owner-initiated invite: owner needs to switch to sitter mode
+                        self.showModeSwitchAlert(for: code)
+                    }
+                } else {
+                    // User is already in sitter mode, proceed directly
+                    self.presentJoinSessionViewController(with: code)
+                }
+            }
+        } catch {
+            Logger.log(level: .error, category: .launcher, message: "Error checking invite type: \(error.localizedDescription)")
+            // On error, fall back to default behavior
+            await MainActor.run {
+                if ModeManager.shared.isNestOwnerMode {
+                    self.showModeSwitchAlert(for: code)
+                } else {
+                    self.presentJoinSessionViewController(with: code)
+                }
             }
         }
     }

--- a/nn-storekit-config.storekit
+++ b/nn-storekit-config.storekit
@@ -17,56 +17,53 @@
 
   ],
   "settings" : {
+    "_askToBuyEnabled" : false,
+    "_billingGracePeriodEnabled" : false,
+    "_billingIssuesEnabled" : false,
+    "_disableDialogs" : false,
     "_failTransactionsEnabled" : false,
     "_locale" : "en_US",
+    "_renewalBillingIssuesEnabled" : false,
     "_storefront" : "USA",
     "_storeKitErrors" : [
       {
-        "current" : null,
         "enabled" : false,
         "name" : "Load Products"
       },
       {
-        "current" : null,
         "enabled" : false,
         "name" : "Purchase"
       },
       {
-        "current" : null,
         "enabled" : false,
         "name" : "Verification"
       },
       {
-        "current" : null,
         "enabled" : false,
         "name" : "App Store Sync"
       },
       {
-        "current" : null,
         "enabled" : false,
         "name" : "Subscription Status"
       },
       {
-        "current" : null,
         "enabled" : false,
         "name" : "App Transaction"
       },
       {
-        "current" : null,
         "enabled" : false,
         "name" : "Manage Subscriptions Sheet"
       },
       {
-        "current" : null,
         "enabled" : false,
         "name" : "Refund Request Sheet"
       },
       {
-        "current" : null,
         "enabled" : false,
         "name" : "Offer Code Redeem Sheet"
       }
-    ]
+    ],
+    "_timeRate" : 0
   },
   "subscriptionGroups" : [
     {
@@ -126,6 +123,94 @@
           "productID" : "yearly",
           "recurringSubscriptionPeriod" : "P1Y",
           "referenceName" : "NestNote Premium Yearly",
+          "subscriptionGroupID" : "D4FCC332",
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "9.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "71FE5803",
+          "introductoryOffer" : {
+            "internalID" : "BCA410DB",
+            "paymentMode" : "free",
+            "subscriptionPeriod" : "P1W"
+          },
+          "localizations" : [
+            {
+              "description" : "",
+              "displayName" : "",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.Swappfunc.nest_note.YearlyPartner",
+          "recurringSubscriptionPeriod" : "P1Y",
+          "referenceName" : "NestNote Premium Yearly Partner",
+          "subscriptionGroupID" : "D4FCC332",
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "2.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "3555B51A",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "",
+              "displayName" : "",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.Swappfunc.nest_note.MonthlyPartner",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "NestNote Premium Monthly Partner",
+          "subscriptionGroupID" : "D4FCC332",
+          "type" : "RecurringSubscription",
+          "winbackOffers" : [
+
+          ]
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "6.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "216FFDB6",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "",
+              "displayName" : "",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "com.Swappfunc.nest_note.YearlyWinback",
+          "recurringSubscriptionPeriod" : "P1Y",
+          "referenceName" : "NestNote Premium Yearly Winback",
           "subscriptionGroupID" : "D4FCC332",
           "type" : "RecurringSubscription",
           "winbackOffers" : [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches onboarding navigation/paywall flows and session creation/editing logic, adds new session status and multiple new view controllers, and includes a visible duplicated/invalid block in `OnboardingCoordinator.next()` that could break navigation at runtime.
> 
> **Overview**
> Bumps the app `MARKETING_VERSION` to **1.2.5** and updates the RevenueCat Purchases SDK pin from **5.28.1 → 5.52.1**.
> 
> Adds a **sitter-initiated “session request”** flow: a new `SessionStatus.pendingOwnerSetup` with UI support (cells, filtering, swipe-to-cancel, and detail/viewing screens), plus owner-side completion via a new `CompleteSitterSessionRequestViewController` that embeds `EditSessionViewController` in a request-completion mode.
> 
> Refactors and centralizes session date handling by introducing `SessionDateValidator` and `SessionDateSynchronizer` (with overnight single-day support), then wires them into session creation/editing, session details, and event editing; also adds smaller UI updates (new segmented filter view wrapper, compact nest cells, improved empty states, and onboarding finish animations including role-specific messaging).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48479702808f05db8c9372b830ccd336528f989c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->