### PR TITLE
Fix sitter referral codes unlocking YearlyPartner pricing

### DIFF
--- a/nest-note/Scenes/Onboarding/OBPaywallViewController.swift
+++ b/nest-note/Scenes/Onboarding/OBPaywallViewController.swift
@@ -39,8 +39,13 @@ final class OBPaywallViewController: NNOnboardingViewController {
         }
         paywall.onPaywallFinished = { [weak self] subscribed in
             let referralCode = paywall.currentReferralCode
+            let referralCodeType = paywall.currentReferralCodeType
             self?.dismissPresentedPaywall {
-                self?.completePaywall(subscribed: subscribed, referralCode: referralCode)
+                self?.completePaywall(
+                    subscribed: subscribed,
+                    referralCode: referralCode,
+                    referralCodeType: referralCodeType
+                )
             }
         }
 
@@ -87,12 +92,16 @@ final class OBPaywallViewController: NNOnboardingViewController {
         (coordinator as? OnboardingCoordinator)?.addPaywallDwellTime(seconds)
     }
 
-    private func completePaywall(subscribed: Bool, referralCode: String?) {
+    private func completePaywall(
+        subscribed: Bool,
+        referralCode: String?,
+        referralCodeType: ReferralCodeType? = nil
+    ) {
         guard !hasCompletedPaywall else { return }
         hasCompletedPaywall = true
 
         if let referralCode {
-            (coordinator as? OnboardingCoordinator)?.updateReferralCode(referralCode)
+            (coordinator as? OnboardingCoordinator)?.updateReferralCode(referralCode, type: referralCodeType)
         }
 
         let dwellSeconds = secondsOnPaywall()
@@ -135,6 +144,10 @@ extension OBPaywallViewController: UIAdaptivePresentationControllerDelegate {
         }
 
         presentedPaywall = nil
-        completePaywall(subscribed: false, referralCode: paywall.currentReferralCode)
+        completePaywall(
+            subscribed: false,
+            referralCode: paywall.currentReferralCode,
+            referralCodeType: paywall.currentReferralCodeType
+        )
     }
 }

--- a/nest-note/Scenes/Onboarding/OnboardingCoordinator.swift
+++ b/nest-note/Scenes/Onboarding/OnboardingCoordinator.swift
@@ -95,6 +95,7 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
         var paywallDwellSeconds: TimeInterval = 0
         var isAppleSignIn: Bool = false
         var referralCode: String?
+        var referralCodeType: ReferralCodeType?
         var venmoUsername: String?
         
         struct NestInfo {
@@ -108,14 +109,12 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
         return userInfo.role
     }
 
-    // Public accessor for paywall offering based on referral code
+    /// Analytics helper — partner offering is for creator codes only.
+    /// Actual package loading is gated by FeatureInfoPaywallViewController.usesCreatorPartnerPricing.
     var paywallOfferingId: String? {
-        // If user has a referral code, show the partner offering
-        if let referralCode = userInfo.referralCode, !referralCode.isEmpty {
-            return "partner"
-        }
-        // Otherwise, use default offering (nil = default)
-        return nil
+        guard let referralCode = userInfo.referralCode, !referralCode.isEmpty else { return nil }
+        guard (userInfo.referralCodeType ?? .creator) == .creator else { return nil }
+        return "partner"
     }
 
     // Public accessor for nest name
@@ -251,7 +250,8 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
             displayName: userInfo.fullName,
             discoveryMethod: userInfo.surveyResponses["discovery_method"]?.first,
             onboardingVariant: onboardingVariant,
-            referralCode: userInfo.referralCode
+            referralCode: userInfo.referralCode,
+            referralCodeType: userInfo.referralCodeType
         )
     }
 
@@ -915,8 +915,11 @@ final class OnboardingCoordinator: NSObject, UINavigationControllerDelegate, Onb
         // Note: role_selection is handled in next() method to ensure proper navigation timing
     }
     
-    func updateReferralCode(_ referralCode: String?) {
-        userInfo.referralCode = referralCode?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true ? nil : referralCode?.trimmingCharacters(in: .whitespacesAndNewlines)
+    func updateReferralCode(_ referralCode: String?, type: ReferralCodeType? = nil) {
+        let trimmed = referralCode?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalized = (trimmed?.isEmpty == true) ? nil : trimmed
+        userInfo.referralCode = normalized
+        userInfo.referralCodeType = normalized == nil ? nil : type
     }
     
     // MARK: - Validation Methods

--- a/nest-note/Scenes/Paywall/FeatureInfoPaywallViewController.swift
+++ b/nest-note/Scenes/Paywall/FeatureInfoPaywallViewController.swift
@@ -47,7 +47,15 @@ final class FeatureInfoPaywallViewController: NNViewController {
     private var loadedPackages: [Package] = []
     private var appliedReferralCode: String?
     private var appliedReferralCodeType: ReferralCodeType?
+
+    /// Partner / YearlyPartner pricing is for creator codes only.
+    /// Sitter referral codes reward the sitter ($10 Venmo) while the family pays full price.
+    private var usesCreatorPartnerPricing: Bool {
+        appliedReferralCode != nil && (appliedReferralCodeType ?? .creator) == .creator
+    }
+
     var currentReferralCode: String? { appliedReferralCode }
+    var currentReferralCodeType: ReferralCodeType? { appliedReferralCodeType }
     var pendingReferralCodeToApply: String?
     var pendingReferralSource: ReferralApplicationSource = .deepLink
     private let referralState = ReferralEntryState()
@@ -739,10 +747,10 @@ final class FeatureInfoPaywallViewController: NNViewController {
         Task {
             do {
                 let sorted: [Package]
-                if appliedReferralCode != nil, !prefetchedPartnerPackages.isEmpty {
+                if usesCreatorPartnerPricing, !prefetchedPartnerPackages.isEmpty {
                     sorted = prefetchedPartnerPackages
                 } else {
-                    let offeringIdentifier = appliedReferralCode == nil ? nil : "partner"
+                    let offeringIdentifier = usesCreatorPartnerPricing ? "partner" : nil
                     let offering = try await SubscriptionService.shared.fetchOffering(identifier: offeringIdentifier)
                     sorted = Self.filteredPaywallPackages(from: offering)
                 }
@@ -750,14 +758,14 @@ final class FeatureInfoPaywallViewController: NNViewController {
                 guard !sorted.isEmpty else {
                     await MainActor.run {
                         setLoading(false)
-                        showError(appliedReferralCode == nil
-                            ? "No subscription plans are available right now."
-                            : "Partner plans aren't available right now.")
+                        showError(usesCreatorPartnerPricing
+                            ? "Partner plans aren't available right now."
+                            : "No subscription plans are available right now.")
                     }
                     return
                 }
 
-                let shouldSlashPrices = appliedReferralCode != nil && !standardComparisonPackages.isEmpty
+                let shouldSlashPrices = usesCreatorPartnerPricing && !standardComparisonPackages.isEmpty
 
                 await MainActor.run {
                     configurePackages(sorted, animatePriceSlash: shouldSlashPrices)
@@ -1086,7 +1094,7 @@ final class FeatureInfoPaywallViewController: NNViewController {
         if stage == .features {
             continueToCheckout()
         } else {
-            loadOffering(identifier: appliedReferralCode == nil ? nil : "partner")
+            loadOffering(identifier: usesCreatorPartnerPricing ? "partner" : nil)
         }
     }
 

--- a/nest-note/Scenes/Paywall/ReferralCodeEntryViewController.swift
+++ b/nest-note/Scenes/Paywall/ReferralCodeEntryViewController.swift
@@ -26,7 +26,7 @@ final class ReferralCodeEntryViewController: UIViewController {
 
     private let subtitleLabel: UILabel = {
         let label = UILabel()
-        label.text = "Support a creator and unlock partner pricing."
+        label.text = "Have a code? Enter it here to apply your referral."
         label.font = .systemFont(ofSize: 15)
         label.textColor = .secondaryLabel
         label.textAlignment = .center

--- a/nest-note/Scenes/Settings/SettingsViewController.swift
+++ b/nest-note/Scenes/Settings/SettingsViewController.swift
@@ -21,13 +21,10 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
     private var nestCreationCoordinator: NestCreationCoordinator?
     private static let settingsPromoHeight: CGFloat = 136
     private static let settingsPromoVerticalPadding: CGFloat = 6
-    private static let sitterReferralBannerHeight: CGFloat = 118
-    private static let sitterReferralBannerVerticalPadding: CGFloat = 0
 
     private var hasProSubscription = true
     private var isFreeTrialEligible = false
     private var readinessScore: Int?
-    private var isCopyingSitterReferralInvite = false
     private var isFirstAppearance = true
     
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
@@ -217,17 +214,6 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
                 section.contentInsets = NSDirectionalEdgeInsets(top: 20, leading: 18, bottom: 20, trailing: 18)
                 return section
 
-            case .sitterReferral:
-                let itemSize = NSCollectionLayoutSize(
-                    widthDimension: .fractionalWidth(1.0),
-                    heightDimension: .absolute(Self.sitterReferralBannerHeight)
-                )
-                let item = NSCollectionLayoutItem(layoutSize: itemSize)
-                let group = NSCollectionLayoutGroup.horizontal(layoutSize: itemSize, subitems: [item])
-                let section = NSCollectionLayoutSection(group: group)
-                section.contentInsets = NSDirectionalEdgeInsets(top: 14, leading: 18, bottom: 14, trailing: 18)
-                return section
-
             case .account:
                 let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(80))
                 let item = NSCollectionLayoutItem(layoutSize: itemSize)
@@ -282,21 +268,6 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
     }
 
     private func configureDataSource() {
-        let sitterReferralCellRegistration = UICollectionView.CellRegistration<PremiumPromoCell, Item> { [weak self] cell, _, item in
-            if case .sitterReferral = item {
-                cell.configure(
-                    variant: .stackedIconsLabel,
-                    ctaTitle: self?.isCopyingSitterReferralInvite == true ? "Copying…" : SitterReferralCopy.ctaTitle,
-                    title: SitterReferralCopy.title,
-                    subtitle: SitterReferralCopy.subtitle,
-                    contentVerticalPadding: Self.sitterReferralBannerVerticalPadding
-                )
-                cell.onUpgradeTapped = { [weak self] in
-                    self?.handleSitterReferralCopyInvite()
-                }
-            }
-        }
-
         let premiumPromoCellRegistration = UICollectionView.CellRegistration<PremiumPromoCell, Item> { [weak self] cell, _, item in
             if case .premiumPromo = item {
                 cell.configure(
@@ -407,12 +378,6 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
                     for: indexPath,
                     item: item
                 )
-            case .sitterReferral:
-                return collectionView.dequeueConfiguredReusableCell(
-                    using: sitterReferralCellRegistration,
-                    for: indexPath,
-                    item: item
-                )
             case .readinessScore:
                 return collectionView.dequeueConfiguredReusableCell(
                     using: readinessScoreCellRegistration,
@@ -446,11 +411,6 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
         if !hasProSubscription && ModeManager.shared.isNestOwnerMode {
             snapshot.appendSections([.premiumPromo])
             snapshot.appendItems([.premiumPromo], toSection: .premiumPromo)
-        }
-
-        if shouldShowSitterReferralBanner {
-            snapshot.appendSections([.sitterReferral])
-            snapshot.appendItems([.sitterReferral], toSection: .sitterReferral)
         }
         
         // Determine sections based on app mode
@@ -488,10 +448,14 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
         // My Nest and My Sitting sections
         if UserService.shared.isSignedIn {
             if ModeManager.shared.isSitterMode {
-                let sittingItems = [
+                var sittingRows = [
                     ("Sessions", "calendar"),
                     ("Saved Nests", "heart"),
-                ].map { Item.myNestItem(title: $0.0, symbolName: $0.1) }
+                ]
+                if shouldShowSitterReferralEntry {
+                    sittingRows.append((SitterReferralCopy.settingsRowTitle, "gift.fill"))
+                }
+                let sittingItems = sittingRows.map { Item.myNestItem(title: $0.0, symbolName: $0.1) }
                 snapshot.appendItems(sittingItems, toSection: .mySitting)
             } else {
                 let nestItems = [
@@ -572,6 +536,7 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
             ("Reset Tooltips", "questionmark.circle.fill"),
             ("Test Subscription Status", "creditcard.circle"),
             ("Feature Info Paywall", "sparkles.rectangle.stack"),
+            ("Sitter Referral Screen", "gift.fill"),
         ].map { Item.experimentalItem(title: $0.0, symbolName: $0.1) }
 
         if isNestReadinessEnabled, NestService.shared.currentNest != nil {
@@ -599,7 +564,6 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
 
     enum Section: String, Hashable, CaseIterable {
         case premiumPromo = "Premium"
-        case sitterReferral = "Refer Friends"
         case account = "Account"
         case currentNest = "Current Nest"
         case myNest = "My Nest"
@@ -611,7 +575,6 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
 
     enum Item: Hashable {
         case premiumPromo
-        case sitterReferral
         case account(email: String, name: String)
         case currentNest(name: String, address: String)
         case readinessScore(score: Int)
@@ -754,6 +717,8 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
             showSubscriptionStatus()
         case "Feature Info Paywall":
             showFeatureInfoPaywall()
+        case "Sitter Referral Screen":
+            presentSitterReferralScreen()
         case "Show on Home Screen":
             showReadinessHomeBannerPicker()
         case "Referral Admin":
@@ -874,8 +839,6 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
         switch item {
         case .premiumPromo:
             presentPremiumPaywall()
-        case .sitterReferral:
-            handleSitterReferralCopyInvite()
         case .readinessScore:
             presentReadinessDetail()
         case .account(let email, let name):
@@ -898,9 +861,11 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
             }
         case .myNestItem(let title, _):
             if UserService.shared.isSignedIn {
-                // Check if there's a current nest (skip check for Sessions in sitter mode)
+                // Check if there's a current nest (skip for sitter-only rows that don't need a nest)
                 let hasCurrentNest = NestService.shared.currentNest != nil
-                if !hasCurrentNest && !(ModeManager.shared.isSitterMode && title == "Sessions") {
+                let skipsNestRequirement = ModeManager.shared.isSitterMode
+                    && (title == "Sessions" || title == SitterReferralCopy.settingsRowTitle)
+                if !hasCurrentNest && !skipsNestRequirement {
                     // Show prompt to set up nest first
                     showNestSetupPrompt()
                     collectionView.deselectItem(at: indexPath, animated: true)
@@ -920,6 +885,8 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
                         let nav = UINavigationController(rootViewController: sessionsVC)
                         present(nav, animated: true)
                     }
+                case SitterReferralCopy.settingsRowTitle:
+                    presentSitterReferralScreen()
                 case "Saved Sitters":
                     let sitterListVC = SitterListViewController(displayMode: .default)
                     let nav = UINavigationController(rootViewController: sitterListVC)
@@ -1033,66 +1000,17 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
         present(nestCreationCoordinator.start(), animated: true)
     }
     
-    private var shouldShowSitterReferralBanner: Bool {
+    private var shouldShowSitterReferralEntry: Bool {
         FeatureFlagService.shared.isEnabled(.sitterReferralProgramEnabled)
             && UserService.shared.isSignedIn
             && ModeManager.shared.isSitterMode
     }
 
-    private func handleSitterReferralCopyInvite() {
-        guard !isCopyingSitterReferralInvite else { return }
-        guard let user = UserService.shared.currentUser else { return }
-
-        let venmo = user.personalInfo.venmoUsername?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if venmo.isEmpty {
-            let alert = UIAlertController(
-                title: "Add Your Venmo",
-                message: "Add your Venmo in Profile so we can pay you when a family subscribes.",
-                preferredStyle: .alert
-            )
-            alert.addAction(UIAlertAction(title: "Go to Profile", style: .default) { [weak self] _ in
-                self?.showUserProfile()
-            })
-            alert.addAction(UIAlertAction(title: "Copy Anyway", style: .default) { [weak self] _ in
-                self?.performSitterReferralCopyInvite(for: user)
-            })
-            alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
-            present(alert, animated: true)
-            return
-        }
-
-        performSitterReferralCopyInvite(for: user)
-    }
-
-    private func performSitterReferralCopyInvite(for user: NestUser) {
-        isCopyingSitterReferralInvite = true
-        applyInitialSnapshots()
-
-        Task {
-            do {
-                let code = try await SitterReferralService.shared.getOrCreateCode(for: user)
-                let message = SitterReferralLinkBuilder.inviteMessage(
-                    sitterName: user.personalInfo.name,
-                    code: code
-                )
-                await MainActor.run {
-                    UIPasteboard.general.string = message
-                    isCopyingSitterReferralInvite = false
-                    applyInitialSnapshots()
-                    showToast(text: "Invite copied!")
-                    HapticsHelper.lightHaptic()
-                    Tracker.shared.trackSitterReferralInviteCopied(
-                        hasVenmo: !(user.personalInfo.venmoUsername ?? "").isEmpty
-                    )
-                }
-            } catch {
-                await MainActor.run {
-                    isCopyingSitterReferralInvite = false
-                    applyInitialSnapshots()
-                    showToast(text: "Couldn't create invite. Try again.")
-                }
-            }
-        }
+    private func presentSitterReferralScreen() {
+        let vc = SitterReferralViewController()
+        let nav = UINavigationController(rootViewController: vc)
+        nav.modalPresentationStyle = .pageSheet
+        present(nav, animated: true)
     }
 
     private func presentPremiumPaywall() {

--- a/nest-note/Scenes/Settings/SitterReferralViewController.swift
+++ b/nest-note/Scenes/Settings/SitterReferralViewController.swift
@@ -1,0 +1,310 @@
+import UIKit
+
+/// Dedicated sitter referral destination — pattern header, benefits, and shareable code.
+final class SitterReferralViewController: NNViewController {
+
+    private let topImageView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        NNAssetHelper.configureImageView(view, for: .rectanglePatternSmall, with: NNColors.primary)
+        view.alpha = 0.4
+        return view
+    }()
+
+    private let infoView: NNBulletStack
+
+    private let scrollView: UIScrollView = {
+        let scroll = UIScrollView()
+        scroll.translatesAutoresizingMaskIntoConstraints = false
+        return scroll
+    }()
+
+    private let containerView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = SitterReferralCopy.title
+        label.font = .h1
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.text = SitterReferralCopy.screenSubtitle
+        label.font = .bodyM
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let codeCard: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .secondarySystemGroupedBackground
+        view.layer.cornerRadius = 16
+        view.layer.cornerCurve = .continuous
+        return view
+    }()
+
+    private let codeCaptionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Your referral code"
+        label.font = .bodyM
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let codeLabel: UILabel = {
+        let label = UILabel()
+        label.text = "••••••"
+        label.font = UIFont.monospacedSystemFont(ofSize: 28, weight: .bold)
+        label.textColor = .label
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.7
+        return label
+    }()
+
+    private lazy var copyCodeButton: UIButton = {
+        var config = UIButton.Configuration.plain()
+        config.title = "Copy Code"
+        config.image = UIImage(systemName: "doc.on.doc")
+        config.imagePadding = 6
+        config.baseForegroundColor = NNColors.primary
+        config.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12)
+        let button = UIButton(configuration: config)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(copyCodeTapped), for: .touchUpInside)
+        return button
+    }()
+
+    private let venmoNoteLabel: UILabel = {
+        let label = UILabel()
+        label.font = .bodyM
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.isHidden = true
+        return label
+    }()
+
+    private lazy var shareInviteButton: NNPrimaryLabeledButton = {
+        let button = NNPrimaryLabeledButton(title: SitterReferralCopy.ctaTitle)
+        button.addTarget(self, action: #selector(shareInviteTapped), for: .touchUpInside)
+        return button
+    }()
+
+    private var referralCode: String?
+    private var isLoadingCode = false
+    private var isSharing = false
+
+    init() {
+        self.infoView = NNBulletStack(items: [
+            NNBulletItem(
+                title: "Share your code",
+                description: "Send families your referral code when they download NestNote and sign up.",
+                iconName: "square.and.arrow.up"
+            ),
+            NNBulletItem(
+                title: "They subscribe at full price",
+                description: "Your code rewards you — it doesn’t discount their plan.",
+                iconName: "creditcard"
+            ),
+            NNBulletItem(
+                title: "Get $10 via Venmo",
+                description: "We pay you after their first paid subscription (not during a free trial).",
+                iconName: "dollarsign.circle.fill"
+            ),
+        ])
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupView()
+        setupNavigationBar()
+        loadReferralCode()
+        updateVenmoNote()
+    }
+
+    private func setupNavigationBar() {
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            image: UIImage(systemName: "xmark"),
+            style: .plain,
+            target: self,
+            action: #selector(closeTapped)
+        )
+    }
+
+    private func setupView() {
+        view.backgroundColor = .systemBackground
+
+        view.addSubview(topImageView)
+        view.addSubview(scrollView)
+        scrollView.addSubview(containerView)
+
+        containerView.addSubview(titleLabel)
+        containerView.addSubview(subtitleLabel)
+        containerView.addSubview(infoView)
+        containerView.addSubview(codeCard)
+        codeCard.addSubview(codeCaptionLabel)
+        codeCard.addSubview(codeLabel)
+        codeCard.addSubview(copyCodeButton)
+        containerView.addSubview(venmoNoteLabel)
+
+        infoView.translatesAutoresizingMaskIntoConstraints = false
+
+        shareInviteButton.pinToBottom(of: view, addBlurEffect: true)
+        topImageView.pinToTop(of: view)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: topImageView.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: shareInviteButton.topAnchor),
+
+            containerView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            containerView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            containerView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            containerView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            containerView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+
+            titleLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 20),
+            titleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 20),
+            titleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -20),
+
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 8),
+            subtitleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 20),
+            subtitleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -20),
+
+            infoView.topAnchor.constraint(equalTo: subtitleLabel.bottomAnchor, constant: 24),
+            infoView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 36),
+            infoView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -36),
+
+            codeCard.topAnchor.constraint(equalTo: infoView.bottomAnchor, constant: 28),
+            codeCard.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 20),
+            codeCard.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -20),
+
+            codeCaptionLabel.topAnchor.constraint(equalTo: codeCard.topAnchor, constant: 16),
+            codeCaptionLabel.leadingAnchor.constraint(equalTo: codeCard.leadingAnchor, constant: 16),
+            codeCaptionLabel.trailingAnchor.constraint(equalTo: codeCard.trailingAnchor, constant: -16),
+
+            codeLabel.topAnchor.constraint(equalTo: codeCaptionLabel.bottomAnchor, constant: 8),
+            codeLabel.leadingAnchor.constraint(equalTo: codeCard.leadingAnchor, constant: 16),
+            codeLabel.trailingAnchor.constraint(equalTo: codeCard.trailingAnchor, constant: -16),
+
+            copyCodeButton.topAnchor.constraint(equalTo: codeLabel.bottomAnchor, constant: 4),
+            copyCodeButton.centerXAnchor.constraint(equalTo: codeCard.centerXAnchor),
+            copyCodeButton.bottomAnchor.constraint(equalTo: codeCard.bottomAnchor, constant: -10),
+
+            venmoNoteLabel.topAnchor.constraint(equalTo: codeCard.bottomAnchor, constant: 16),
+            venmoNoteLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 28),
+            venmoNoteLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -28),
+            venmoNoteLabel.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -24),
+        ])
+    }
+
+    private func loadReferralCode() {
+        guard !isLoadingCode else { return }
+        guard let user = UserService.shared.currentUser else {
+            codeLabel.text = "Sign in required"
+            shareInviteButton.isEnabled = false
+            copyCodeButton.isEnabled = false
+            return
+        }
+
+        isLoadingCode = true
+        shareInviteButton.isEnabled = false
+        copyCodeButton.isEnabled = false
+        codeLabel.text = "Generating…"
+
+        Task {
+            do {
+                let code = try await SitterReferralService.shared.getOrCreateCode(for: user)
+                await MainActor.run {
+                    referralCode = code
+                    codeLabel.text = code
+                    shareInviteButton.isEnabled = true
+                    copyCodeButton.isEnabled = true
+                    isLoadingCode = false
+                }
+            } catch {
+                await MainActor.run {
+                    codeLabel.text = "Couldn't load"
+                    shareInviteButton.isEnabled = false
+                    copyCodeButton.isEnabled = false
+                    isLoadingCode = false
+                    showToast(text: "Couldn't create your code. Try again.")
+                }
+            }
+        }
+    }
+
+    private func updateVenmoNote() {
+        let venmo = UserService.shared.currentUser?.personalInfo.venmoUsername?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if venmo.isEmpty {
+            venmoNoteLabel.text = SitterReferralCopy.missingVenmoNote
+            venmoNoteLabel.isHidden = false
+        } else {
+            venmoNoteLabel.isHidden = true
+        }
+    }
+
+    @objc private func closeTapped() {
+        dismiss(animated: true)
+    }
+
+    @objc private func copyCodeTapped() {
+        guard let code = referralCode, !code.isEmpty else { return }
+        UIPasteboard.general.string = code
+        HapticsHelper.lightHaptic()
+        showToast(text: "Code copied!")
+    }
+
+    @objc private func shareInviteTapped() {
+        guard !isSharing, let code = referralCode, !code.isEmpty else { return }
+        guard let user = UserService.shared.currentUser else { return }
+
+        isSharing = true
+        let message = SitterReferralLinkBuilder.inviteMessage(
+            sitterName: user.personalInfo.name,
+            code: code
+        )
+
+        let activityVC = UIActivityViewController(activityItems: [message], applicationActivities: nil)
+        activityVC.completionWithItemsHandler = { [weak self] _, completed, _, _ in
+            guard let self else { return }
+            self.isSharing = false
+            if completed {
+                HapticsHelper.lightHaptic()
+                Tracker.shared.trackSitterReferralInviteCopied(
+                    hasVenmo: !(user.personalInfo.venmoUsername ?? "").isEmpty
+                )
+            }
+        }
+
+        if let popover = activityVC.popoverPresentationController {
+            popover.sourceView = shareInviteButton
+            popover.sourceRect = shareInviteButton.bounds
+        }
+
+        present(activityVC, animated: true)
+    }
+}

--- a/nest-note/Services/RevenueCatAttributeService.swift
+++ b/nest-note/Services/RevenueCatAttributeService.swift
@@ -20,14 +20,16 @@ final class RevenueCatAttributeService {
         displayName: String,
         discoveryMethod: String?,
         onboardingVariant: String,
-        referralCode: String?
+        referralCode: String?,
+        referralCodeType: ReferralCodeType? = nil
     ) {
         applySubscriberAttributes(email: email, phone: phone, displayName: displayName)
         applyCustomAttributes(buildOnboardingCustomAttributes(
             firebaseUID: nil,
             discoveryMethod: discoveryMethod,
             onboardingVariant: onboardingVariant,
-            referralCode: referralCode
+            referralCode: referralCode,
+            referralCodeType: referralCodeType
         ))
         syncAttributes()
 

--- a/nest-note/Services/SitterReferralLinkBuilder.swift
+++ b/nest-note/Services/SitterReferralLinkBuilder.swift
@@ -2,8 +2,12 @@ import Foundation
 
 enum SitterReferralCopy {
     static let title = "Earn $10 per family"
-    static let subtitle = "Invite a family to NestNote. When they subscribe, you get $10 via Venmo."
-    static let ctaTitle = "Copy Invite"
+    static let screenSubtitle = "Invite a family to NestNote. When they subscribe, you get $10 via Venmo."
+    /// Short subtitle kept for any compact surfaces.
+    static let subtitle = screenSubtitle
+    static let ctaTitle = "Share Invite"
+    static let settingsRowTitle = "Refer Families"
+    static let missingVenmoNote = "Add your Venmo in Profile so we can pay you when a family subscribes."
 }
 
 enum SitterReferralLinkBuilder {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Findings

Yes — sitter referrals were implemented wrong on the live paywall.

**Intended model**
- **Creator codes** → family gets partner / YearlyPartner discount
- **Sitter codes** → family pays full price; sitter gets $10 Venmo after a paid conversion

**What was happening**
`FeatureInfoPaywallViewController` (the onboarding paywall) loaded the `"partner"` offering for *any* applied referral code. Carousel paywalls already gated correctly with `usesCreatorPartnerPricing` (creator only).

## Fixes

### 1. Partner pricing gate
- Gate FeatureInfo partner offering / price slash / retry on `ReferralCodeType.creator` only
- Track referral code type through onboarding completion + RC pre-paywall sync
- Neutralize referral sheet copy that implied every code unlocks partner pricing

### 2. Sitter referral screen (new)
Replaces the janky Settings `PremiumPromoCell` banner with a proper destination:

- Settings → My Sitting → **Refer Families** (feature-flagged)
- Pattern header + title/subtitle
- `NNBulletStack`: share code → family pays full price → $10 via Venmo after paid sub
- Code card with generated code + **Copy Code**
- Soft Venmo note when missing (no blocking alert)
- Primary CTA: **Share Invite** (`UIActivityViewController`)
- DEBUG: Experimental → “Sitter Referral Screen”

## Pending payouts (unchanged behavior)

Pending rows are **admin-only** (Settings → Admin → Sitter Referral Payouts, DEBUG), created by the RC webhook after a **paid** purchase with `referral_code_type=sitter`. Free trials do not create a row. Sitters still don’t get a pending/earned list on this screen — that can be a follow-up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f70fc-1ae3-78fe-a379-2f263504646e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f70fc-1ae3-78fe-a379-2f263504646e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

