### PR TITLE
Add Release Notes sheet to Settings

### DIFF
--- a/nest-note/Resources/release-notes.md
+++ b/nest-note/Resources/release-notes.md
@@ -1,0 +1,17 @@
+# Release Notes
+
+What's new in NestNote.
+
+---
+
+## 1.3.1
+
+- Improved sitter invite creation flow
+- Sitter referral updates and clearer referral screen
+- Onboarding polish and preview improvements
+
+## 1.3.0
+
+- Sitter referral program
+- Referral analytics and payout tracking for sitters
+- Stability and performance improvements

--- a/nest-note/Scenes/Settings/ReleaseNotesArticle.swift
+++ b/nest-note/Scenes/Settings/ReleaseNotesArticle.swift
@@ -1,0 +1,34 @@
+//
+//  ReleaseNotesArticle.swift
+//  nest-note
+//
+//  Loads in-app release notes from Resources/release-notes.md.
+//  Update that markdown file with each App Store release.
+//
+
+import Foundation
+
+enum ReleaseNotesArticle {
+
+    private static let resourceName = "release-notes"
+
+    static var markdown: String {
+        guard let url = Bundle.main.url(forResource: resourceName, withExtension: "md"),
+              let text = try? String(contentsOf: url, encoding: .utf8),
+              !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            Logger.log(
+                level: .error,
+                category: .general,
+                message: "Failed to load bundled markdown: \(resourceName).md"
+            )
+            return fallbackMarkdown
+        }
+        return text
+    }
+
+    private static let fallbackMarkdown = """
+    # Release Notes
+
+    We couldn't load release notes right now. Please try again, or contact support@nestnoteapp.com for help.
+    """
+}

--- a/nest-note/Scenes/Settings/SettingsViewController.swift
+++ b/nest-note/Scenes/Settings/SettingsViewController.swift
@@ -1008,6 +1008,8 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
             switch title {
             case "How It Works":
                 showHowItWorks()
+            case "Release Notes":
+                showReleaseNotes()
             case "Text Support":
                 showTextSupport()
             case "Contact Support":
@@ -1281,6 +1283,7 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
     private func makeSupportItems() -> [Item] {
         var items: [(String, String)] = [
             ("How It Works", "book.pages"),
+            ("Release Notes", "sparkles"),
         ]
 
         if FeatureFlagService.shared.isEnabled(.supportTextEnabled) {
@@ -1297,6 +1300,21 @@ class SettingsViewController: NNViewController, UICollectionViewDelegate, NNTipp
             showsShareButton: false
         )
         navigationController?.pushViewController(vc, animated: true)
+    }
+
+    private func showReleaseNotes() {
+        let vc = MarkdownTestViewController(
+            markdown: ReleaseNotesArticle.markdown,
+            showsShareButton: false
+        )
+        vc.modalPresentationStyle = .pageSheet
+
+        if let sheet = vc.sheetPresentationController {
+            sheet.detents = [.large()]
+            sheet.prefersGrabberVisible = false
+        }
+
+        present(vc, animated: true)
     }
 
     private func showTextSupport() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a **Release Notes** row under Support in Settings, backed by a bundled markdown file you can update each release.

### What’s included
- `Resources/release-notes.md` — source of truth for What’s New copy
- `ReleaseNotesArticle` — loads the markdown from the app bundle (same pattern as How It Works)
- Settings Support row that presents `MarkdownTestViewController` as a `.pageSheet` with the existing brand pattern banner and close control

### How to update each release
Edit `nest-note/Resources/release-notes.md` and ship it with the release. No code changes needed unless you want to change presentation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc4d3-043e-7562-ac8d-4218c151ee97?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc4d3-043e-7562-ac8d-4218c151ee97&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

